### PR TITLE
Use load balanced API to eliminate CORS pre-flight requests DEV-217

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,12 @@ ID = "salad-web-app"
   # Default build command.
   command = "yarn build"
 
+# The following redirect proxies API requests to the backend.
+[[redirects]]
+  from = "/api/*"
+  to = "https://app-api.salad.io/api/:splat"
+  status = 200
+
 # The following redirect is intended for use with most SPAs that handle
 # routing internally.
 [[redirects]]

--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -2,7 +2,7 @@
 REACT_APP_AUTH0_DOMAIN=login.salad.io
 
 # API
-REACT_APP_API_URL=https://app-api.salad.io/api/v1/
+REACT_APP_API_URL=https://app.salad.io/api/v1/
 
 REACT_APP_TERMS_VERSION=1.0
 REACT_APP_WHATS_NEW_VERSION=0.2.0


### PR DESCRIPTION
@dsarfati and @thedigitaldesign, are there any other configuration values (or hardcoded constants) that need to get updated?

With the new network topology, all traffic to `https://app.salad.io` will get routed to the load balancer. The load balancer will then route traffic as follows (in order):

> 1. https://app.salad.io/api/* -> API
> 2. https://app.salad.io/* -> Application

The `app-api.salad.io` subdomain will be retired.