### PR TITLE
Salad Support Page Redirect Add DEV-368

### DIFF
--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -8,6 +8,6 @@ REACT_APP_WHATS_NEW_VERSION=0.2.0
 REACT_APP_DATA_TRACKING_VERSION=1.0
 REACT_APP_VERSION=0.2.0
 
-REACT_APP_SUPPORT_URL=https://salad.zendesk.com
+REACT_APP_SUPPORT_URL=https://www.salad.io/support/
 REACT_APP_DISCORD_URL=https://discord.gg/xcvmgQk
 REACT_APP_RELEASES_URL=https://www.salad.io/release-notes/


### PR DESCRIPTION
Clicking the support button will now lead to https://www.salad.io/support/ instead of Zendesk