### PR TITLE
DEV-490 & DEV-488

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -19,7 +19,6 @@ class App extends Component {
     }
 
     console.log('Running in native env')
-    this.store.native.loadMachineInfo()
   }
 
   render() {

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -44,7 +44,7 @@ export class RootStore {
     this.analytics = new AnalyticsStore()
     this.routing = new RouterStore()
     this.xp = new ExperienceStore(this, axios)
-    this.machine = new MachineStore(this)
+    this.machine = new MachineStore()
     this.native = new NativeStore(this, axios)
     this.auth = new AuthStore(this, axios)
     this.token = new TokenStore()

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -44,7 +44,7 @@ export class RootStore {
     this.analytics = new AnalyticsStore()
     this.routing = new RouterStore()
     this.xp = new ExperienceStore(this, axios)
-    this.machine = new MachineStore()
+    this.machine = new MachineStore(this)
     this.native = new NativeStore(this, axios)
     this.auth = new AuthStore(this, axios)
     this.token = new TokenStore()
@@ -61,7 +61,16 @@ export class RootStore {
     this.referral.loadReferralCode()
     this.xp.refreshXp()
     this.referral.loadCurrentReferral()
-    yield this.native.registerMachine()
+
+    // Before we can registerMachine we need machineInfo
+    let machineInfoHeartbeat = setInterval(() => {
+      if (this.native.machineInfo) {
+        this.native.registerMachine()
+        clearInterval(machineInfoHeartbeat)
+      }
+
+      this.native.loadMachineInfo()
+    }, 1000)
   })
 
   @action

--- a/packages/web-app/src/modules/machine/MachineStore.ts
+++ b/packages/web-app/src/modules/machine/MachineStore.ts
@@ -1,14 +1,29 @@
 import { action, observable, computed } from 'mobx'
 import { Machine } from './models/Machine'
+import { RootStore } from '../../Store'
 
 export class MachineStore {
   @observable
   public currentMachine?: Machine
 
   @computed
-  get currentEarningRate(): number {
-    return this.currentMachine ? this.currentMachine.earningRate : 0
+  get currentEarningRate(): string {
+    let earningRate = 'Loading'
+
+    if (this.store.native.machineInfo) {
+      if (this.currentMachine) {
+        if (this.currentMachine.earningRate) {
+          earningRate = `$${(this.currentMachine.earningRate * 86400).toFixed(3)}/day`
+        } else {
+          earningRate = '$0.000/day'
+        }
+      }
+    }
+
+    return earningRate
   }
+
+  constructor(private readonly store: RootStore) {}
 
   @action
   setCurrentMachine = (machine: Machine) => {

--- a/packages/web-app/src/modules/machine/MachineStore.ts
+++ b/packages/web-app/src/modules/machine/MachineStore.ts
@@ -1,6 +1,5 @@
 import { action, observable, computed } from 'mobx'
 import { Machine } from './models/Machine'
-import { RootStore } from '../../Store'
 
 export class MachineStore {
   @observable
@@ -10,25 +9,6 @@ export class MachineStore {
   get currentEarningRate(): number {
     return this.currentMachine ? this.currentMachine.earningRate : 0
   }
-
-  @computed
-  get formattedCurrentEarningRate(): string {
-    let earningRate = 'Loading'
-
-    if (this.store.native.machineInfo) {
-      if (this.currentMachine) {
-        if (this.currentMachine.earningRate) {
-          earningRate = `$${(this.currentMachine.earningRate * 86400).toFixed(3)}/day`
-        } else {
-          earningRate = '$0.000/day'
-        }
-      }
-    }
-
-    return earningRate
-  }
-
-  constructor(private readonly store: RootStore) {}
 
   @action
   setCurrentMachine = (machine: Machine) => {

--- a/packages/web-app/src/modules/machine/MachineStore.ts
+++ b/packages/web-app/src/modules/machine/MachineStore.ts
@@ -7,7 +7,12 @@ export class MachineStore {
   public currentMachine?: Machine
 
   @computed
-  get currentEarningRate(): string {
+  get currentEarningRate(): number {
+    return this.currentMachine ? this.currentMachine.earningRate : 0
+  }
+
+  @computed
+  get formattedCurrentEarningRate(): string {
     let earningRate = 'Loading'
 
     if (this.store.native.machineInfo) {

--- a/packages/web-app/src/modules/machine/NativeStore.ts
+++ b/packages/web-app/src/modules/machine/NativeStore.ts
@@ -246,7 +246,7 @@ export class NativeStore {
 
   @action
   loadMachineInfo = () => {
-    if (this.machineInfo || this.loadingMachineInfo) {
+    if (this.machineInfo) {
       console.log('Machine info already loaded. Skipping...')
       return
     }
@@ -325,6 +325,7 @@ export class NativeStore {
       console.log('Registering machine with salad')
       let res: any = yield this.axios.post(`machines/${this.machineId}/data`, this.machineInfo)
       let machine: Machine = res.data
+
       this.validGPUs = machine.validGpus
       this.validOperatingSystem = machine.validOs
       this.store.machine.setCurrentMachine(machine)
@@ -348,6 +349,7 @@ export class NativeStore {
     this.store.analytics.trackMachineInfo(info)
     this.skippedCompatCheck = this.validOperatingSystem && this.validGPUs
     this.loadingMachineInfo = false
+
     this.store.routing.replace('/')
   }
 
@@ -402,8 +404,6 @@ export class NativeStore {
 
   @action
   hashrateHeartbeat = (runStatus: boolean, machineStatus: string) => {
-    console.log('[[NativeStore] hashrateHeartbeat] machineStatus: ', machineStatus)
-
     if (runStatus && this.isNative) {
       this.send(getHashrate)
       this.setHashrateFromLog()

--- a/packages/web-app/src/modules/profile-views/UserStatsSummaryContainer.ts
+++ b/packages/web-app/src/modules/profile-views/UserStatsSummaryContainer.ts
@@ -3,7 +3,7 @@ import { RootStore } from '../../Store'
 import { UserStatsSummary } from './components/UserStatsSummary'
 
 const mapStoreToProps = (store: RootStore) => ({
-  earningRate: store.machine.currentEarningRate,
+  earningRate: store.machine.formattedCurrentEarningRate,
   miningStatus: store.native.miningStatus,
 })
 

--- a/packages/web-app/src/modules/profile-views/UserStatsSummaryContainer.ts
+++ b/packages/web-app/src/modules/profile-views/UserStatsSummaryContainer.ts
@@ -2,10 +2,24 @@ import { connect } from '../../connect'
 import { RootStore } from '../../Store'
 import { UserStatsSummary } from './components/UserStatsSummary'
 
-const mapStoreToProps = (store: RootStore) => ({
-  earningRate: store.machine.formattedCurrentEarningRate,
-  miningStatus: store.native.miningStatus,
-})
+const mapStoreToProps = (store: RootStore) => {
+  let earningRate = 'Loading'
+
+  if (store.native.machineInfo) {
+    if (store.machine.currentMachine) {
+      if (store.machine.currentEarningRate) {
+        earningRate = `$${(store.machine.currentEarningRate * 86400).toFixed(3)}/day`
+      } else {
+        earningRate = '$0.000/day'
+      }
+    }
+  }
+
+  return {
+    earningRate: earningRate,
+    miningStatus: store.native.miningStatus,
+  }
+}
 
 export const UserStatsSummaryContainer = connect(
   mapStoreToProps,

--- a/packages/web-app/src/modules/profile-views/components/ProfileViews.stories.tsx
+++ b/packages/web-app/src/modules/profile-views/components/ProfileViews.stories.tsx
@@ -36,7 +36,7 @@ storiesOf('Modules/Profile', module)
     return <SettingsModalPage onCloseClicked={action('close')} onSendBug={action('new bug')} />
   })
   .add('User Stats', () => {
-    return <UserStatsSummary earningRate={0.0001} />
+    return <UserStatsSummary earningRate={'0.0001'} />
   })
   .add('Edit Username', () => {
     return (

--- a/packages/web-app/src/modules/profile-views/components/UserStatsSummary.tsx
+++ b/packages/web-app/src/modules/profile-views/components/UserStatsSummary.tsx
@@ -14,7 +14,7 @@ const styles = (theme: SaladTheme) => ({
 
 interface Props extends WithStyles<typeof styles> {
   /** The earning rate (USD/s) */
-  earningRate?: number
+  earningRate?: string
   miningStatus?: string
 }
 
@@ -24,10 +24,7 @@ class _UserStatsSummary extends Component<Props> {
     return (
       <div className={classes.container}>
         <StatElement title="Mining status" values={[miningStatus || 'Stopped']} />
-        <StatElement
-          title="Earning Rate"
-          values={[`${earningRate !== undefined ? (earningRate * 86400).toFixed(3) : '0.000'}/day`]}
-        />
+        <StatElement title="Earning Rate" values={[earningRate || 'Loading']} />
       </div>
     )
   }


### PR DESCRIPTION
- Added in an interval that hits loadMachineInfo until we have machineInfo
-- This is a ugly, but is needed to ensure we have set machineInfo.
- Found that the earningRate was tied to this issue. Without machineInfo we couldn't get the user and their earning rate. On refresh we would fetch it, but now it is updated when we get machineInfo from the setInterval
- Added in 'Loading' under Earning Rate while we are fetching machineInfo. Moved the logic off of the .tsx and onto the store