### PR TITLE
Add Claymore fallback pools and improve fast failure scenarios DEV-915

### DIFF
--- a/packages/desktop-app/src/salad-bowl/Plugin.ts
+++ b/packages/desktop-app/src/salad-bowl/Plugin.ts
@@ -236,9 +236,13 @@ export class Plugin {
 
     if (this.pluginDefinition.autoRestart === false) {
       console.log(`Auto restart is disabled for ${this.name}`)
+      if (!stopped) {
+        await this.stop()
+      }
+
       return
     }
-    //If the plugin was intentionally stopped
+
     if (this.status === PluginStatus.Stopped || stopped) {
       return
     }

--- a/packages/desktop-app/src/salad-bowl/Plugin.ts
+++ b/packages/desktop-app/src/salad-bowl/Plugin.ts
@@ -58,6 +58,7 @@ export class Plugin {
       }
     }
     this.status = PluginStatus.Initializing
+    this.stopCalled = false
 
     //Adds any extra files
     if (this.pluginDefinition.extraFiles) {

--- a/packages/web-app/src/modules/salad-bowl/definitions/getClaymoreDefinition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getClaymoreDefinition.ts
@@ -2,14 +2,20 @@ import { Machine } from '../../machine/models/Machine'
 import { PluginDefinition } from '../models'
 import { MINING_ADDRESS, STANDARD_ERRORS } from './constants'
 
+const claymoreRegion = (location: string) => `-epool daggerhashimoto.${location}.nicehash.com:3353`
+
 export const getClaymoreDefinition = (machine: Machine): PluginDefinition => {
   let def = {
     name: 'Claymore-15',
     downloadUrl:
       'https://github.com/SaladTechnologies/plugin-downloads/releases/download/claymore15/claymore-15-windows.zip',
     exe: 'EthDcrMiner64.exe',
-    args: `-esm 3 -ewal ${MINING_ADDRESS}.${machine.minerId} -epool daggerhashimoto.usa.nicehash.com:3353 -allpools 1 -allcoins 0`,
-    runningCheck: 'ETH: GPU0 [1-9]+(.[0-9][0-9][0-9]?)? [KMG]h/s',
+    args: `-esm 3 -ewal ${MINING_ADDRESS}.${machine.minerId} ${claymoreRegion('usa')} ${claymoreRegion(
+      'eu',
+    )} ${claymoreRegion('hk')} ${claymoreRegion('jp')} ${claymoreRegion('in')} ${claymoreRegion(
+      'br',
+    )} -allpools 1 -allcoins 0`,
+    runningCheck: 'ETH: GPU[0-9]+ [1-9]+(\\.[0-9][0-9][0-9]?)? [KMG]h/s',
     initialTimeout: 600000,
     initialRetries: 3,
     errors: [...STANDARD_ERRORS],

--- a/packages/web-app/src/modules/salad-bowl/definitions/getGminerBeamV2Definition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getGminerBeamV2Definition.ts
@@ -17,7 +17,7 @@ export const getGminerBeamV2Definition = (machine: Machine): PluginDefinition =>
     )} ${beamUser('jp', machine.minerId)} ${beamUser('in', machine.minerId)} ${beamUser('br', machine.minerId)}`,
     runningCheck: 'Share Accepted',
     initialTimeout: 600000,
-    initialRetries: 1,
+    initialRetries: 0,
     errors: [...STANDARD_ERRORS],
   }
 

--- a/packages/web-app/src/modules/salad-bowl/definitions/getGminerBeamV2Definition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getGminerBeamV2Definition.ts
@@ -11,13 +11,13 @@ export const getGminerBeamV2Definition = (machine: Machine): PluginDefinition =>
     downloadUrl:
       'https://github.com/SaladTechnologies/plugin-downloads/releases/download/gminer1.83/gminer-1-83-windows.zip',
     exe: 'miner.exe',
-    args: `-a beamhashII ${beamUser('usa', machine.minerId)} ${beamUser('eu', machine.minerId)} ${beamUser(
+    args: `-w 0 -a beamhashII ${beamUser('usa', machine.minerId)} ${beamUser('eu', machine.minerId)} ${beamUser(
       'hk',
       machine.minerId,
     )} ${beamUser('jp', machine.minerId)} ${beamUser('in', machine.minerId)} ${beamUser('br', machine.minerId)}`,
     runningCheck: 'Share Accepted',
     initialTimeout: 600000,
-    initialRetries: 3,
+    initialRetries: 1,
     errors: [...STANDARD_ERRORS],
   }
 

--- a/packages/web-app/src/modules/salad-bowl/definitions/getGminerEthDefinition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getGminerEthDefinition.ts
@@ -13,13 +13,13 @@ export const getGminerEthDefinition = (machine: Machine): PluginDefinition => {
     downloadUrl:
       'https://github.com/SaladTechnologies/plugin-downloads/releases/download/gminer1.83/gminer-1-83-windows.zip',
     exe: 'miner.exe',
-    args: `-a eth ${daggerRegion('usa', machine)} ${daggerRegion('eu', machine)} ${daggerRegion(
+    args: `-w 0 -a eth ${daggerRegion('usa', machine)} ${daggerRegion('eu', machine)} ${daggerRegion(
       'hk',
       machine,
     )} ${daggerRegion('jp', machine)} ${daggerRegion('in', machine)} ${daggerRegion('br', machine)}`,
     runningCheck: '.*[1-9]d* [KMG]H/s ',
     initialTimeout: 600000,
-    initialRetries: 3,
+    initialRetries: 1,
     errors: [...STANDARD_ERRORS],
   }
 

--- a/packages/web-app/src/modules/salad-bowl/definitions/getGminerEthDefinition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getGminerEthDefinition.ts
@@ -19,7 +19,7 @@ export const getGminerEthDefinition = (machine: Machine): PluginDefinition => {
     )} ${daggerRegion('jp', machine)} ${daggerRegion('in', machine)} ${daggerRegion('br', machine)}`,
     runningCheck: '.*[1-9]d* [KMG]H/s ',
     initialTimeout: 600000,
-    initialRetries: 1,
+    initialRetries: 0,
     errors: [...STANDARD_ERRORS],
   }
 


### PR DESCRIPTION
This adds fallback pools when using Claymore. This also reduces the time it takes for pool failures to be detected when using Gminer.