### PR TITLE
Filter Ethash plugins for lower-end GPUs

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/PluginDefinitionFactory.ts
+++ b/packages/web-app/src/modules/salad-bowl/PluginDefinitionFactory.ts
@@ -26,11 +26,7 @@ export const getPluginDefinitions = (store: RootStore): PluginDefinition[] => {
   const pluginDefinitions: PluginDefinition[] = []
 
   // Ethereum / Ethash
-  if (preferNiceHash && has4gbSupport) {
-    pluginDefinitions.push(getClaymoreEthashDefinition(machine)) // NiceHash
-    pluginDefinitions.push(getClaymoreEthashBitflyDefinition(machine)) // Bitfly's Ethermine
-  } else {
-    pluginDefinitions.push(getClaymoreEthashBitflyDefinition(machine)) // Bitfly's Ethermine
+  if (has4gbSupport) {
     pluginDefinitions.push(getClaymoreEthashDefinition(machine)) // NiceHash
   }
 
@@ -63,6 +59,11 @@ export const getPluginDefinitions = (store: RootStore): PluginDefinition[] => {
 
   // Vertcoin / Lyra2REv3
   pluginDefinitions.push(getCCMinerLyra2REv3Definition(machine)) // NiceHash
+
+  // Fallback: Ethereum / Ethash
+  if (has4gbSupport) {
+    pluginDefinitions.push(getClaymoreEthashBitflyDefinition(machine)) // Bitfly's Ethermine
+  }
 
   // Fallback: Ethereum / Ethash
   if (has4gbSupport) {


### PR DESCRIPTION
This fixes a missing 4GB VRAM check, and it moves the Ethermine plugin to the end of the fallback list due to an unknown EPERM issue.