### PR TITLE
Move the offerwall fine print

### DIFF
--- a/packages/web-app/src/modules/earn-views/components/Offerwall.tsx
+++ b/packages/web-app/src/modules/earn-views/components/Offerwall.tsx
@@ -114,6 +114,14 @@ class _Offerwall extends Component<Props> {
                     By partnering with AdGem, we now host a large catalog of offers, most of which are easily completed
                     and all provide extra earnings.
                   </P>
+                  <P>
+                    <P>{disclaimer}</P>
+                    <i>
+                      - It may take up to 24 hours to receive your balance <br />
+                      - BlueStacks or other device emulators may not be supported by offerwall providers
+                      <br />- The use of a VPN may result in a ban by the offerwall provider
+                    </i>
+                  </P>
                 </div>
                 <br />
                 <P>Example</P>
@@ -127,14 +135,6 @@ class _Offerwall extends Component<Props> {
                   >
                     Check out our FAQ for more info!
                   </ExternalLink>
-                </P>
-                <P>
-                  <P>{disclaimer}</P>
-                  <i>
-                    - It may take up to 24 hours to receive your balance <br />
-                    - BlueStacks or other device emulators may not be supported by offerwall providers
-                    <br />- The use of a VPN may result in a ban by the offerwall provider
-                  </i>
                 </P>
               </div>
             </div>


### PR DESCRIPTION
Considering a part of the "fine print" is mentioned at the top with the offerwall enabled,
![image](https://user-images.githubusercontent.com/46850780/77805777-0c714d00-7083-11ea-9ea2-10f32648434f.png)
it's probably a good idea to move the fine print higher up in the "disabled" view (consistency!)