### PR TITLE
Clarify example offerwall image

### DIFF
--- a/packages/web-app/src/modules/earn-views/components/Offerwall.tsx
+++ b/packages/web-app/src/modules/earn-views/components/Offerwall.tsx
@@ -70,7 +70,7 @@ class _Offerwall extends Component<Props> {
                 </P>
               </div>
               <br />
-              <P>Example Offers</P>
+              <P>Example AdGem Offers</P>
               <Img className={classes.exampleImage} src={offerWallExample} />
               <P>
                 <P>


### PR DESCRIPTION
Currently Salad just refers to the image as "Example Offers", but the interfaces vary between offerwall to offerwall.