### PR TITLE
Ignore ResizeObserver error

### DIFF
--- a/packages/web-app/src/index.tsx
+++ b/packages/web-app/src/index.tsx
@@ -31,6 +31,7 @@ allSettled.shim()
 
 Sentry.init({
   dsn: config.sentryDSN,
+  ignoreErrors: ['ResizeObserver loop limit exceeded'],
   release: config.appBuild,
 })
 


### PR DESCRIPTION
A benign error message... ignoring it to reduce the noise in Sentry.