### PR TITLE
Log system information

### DIFF
--- a/packages/web-app/src/modules/machine/NativeStore.ts
+++ b/packages/web-app/src/modules/machine/NativeStore.ts
@@ -184,7 +184,8 @@ export class NativeStore {
 
   @action
   setMachineInfo = (info: MachineInfo) => {
-    console.log('Received machine info')
+    const { services: _, ...logInfo } = info
+    console.log(`Received machine info: ${JSON.stringify(logInfo)}`)
     if (this.machineInfo) {
       console.log('Already received machine info. Skipping...')
 


### PR DESCRIPTION
A lot of technical support requests follow the pattern of asking a user to confirm their GPU make & model followed up by asking for a copy of the application log file. This is an attempt to speed up the process, get both pieces of information at once.