### PR TITLE
Restore persisted "Close to Tray" options

### DIFF
--- a/packages/web-app/src/modules/settings-views/windows-settings-views/WindowsSettingsContainer.ts
+++ b/packages/web-app/src/modules/settings-views/windows-settings-views/WindowsSettingsContainer.ts
@@ -6,13 +6,15 @@ const mapStoreToProps = (store: RootStore): any => ({
   autoLaunch: store.native.autoLaunch,
   autoLaunchToggle: store.native.toggleAutoLaunch,
   autoStart: store.autoStart.autoStart,
-  autoStartToggle: store.autoStart.toggleAutoStart,
-  autoStartEnabled: store.autoStart.canAutoStart,
   autoStartDelay: store.autoStart.idleThreshold,
+  autoStartEnabled: store.autoStart.canAutoStart,
+  autoStartToggle: store.autoStart.toggleAutoStart,
   autoStartUpdate: store.autoStart.setIdleTime,
-  minimizeToTrayToggle: store.native.toggleMinimizeToTray,
-  minimizeToTray: store.native.minimizeToTray,
   canMinimizeToTray: store.native.canMinimizeToTray,
+  minimizeToTray: store.native.minimizeToTray,
+  minimizeToTrayToggle: store.native.toggleMinimizeToTray,
+  notifyOnMinimizeToTray: store.native.notifyOnMinimizeToTray,
+  notifyOnMinimizeToTrayToggle: store.native.toggleNotifyOnMinimizeToTray,
 })
 
 export const WindowsSettingsContainer = connect(mapStoreToProps, WindowsSettings)

--- a/packages/web-app/src/modules/settings-views/windows-settings-views/components/WindowsSettings.tsx
+++ b/packages/web-app/src/modules/settings-views/windows-settings-views/components/WindowsSettings.tsx
@@ -22,13 +22,15 @@ interface Props extends WithStyles<typeof styles> {
   autoLaunch?: boolean
   autoLaunchToggle?: () => void
   autoStart?: boolean
-  autoStartToggle?: () => void
-  autoStartEnabled?: boolean
   autoStartDelay?: number
+  autoStartEnabled?: boolean
+  autoStartToggle?: () => void
   autoStartUpdate?: (value: number) => void
-  minimizeToTrayToggle?: () => void
-  minimizeToTray?: boolean
   canMinimizeToTray?: boolean
+  minimizeToTray?: boolean
+  minimizeToTrayToggle?: () => void
+  notifyOnMinimizeToTray?: boolean
+  notifyOnMinimizeToTrayToggle?: () => void
 }
 
 class _WindowsSettings extends Component<Props> {
@@ -37,14 +39,16 @@ class _WindowsSettings extends Component<Props> {
       autoLaunch,
       autoLaunchToggle,
       autoStart,
-      autoStartToggle,
-      autoStartEnabled,
       autoStartDelay,
+      autoStartEnabled,
+      autoStartToggle,
       autoStartUpdate,
-      minimizeToTrayToggle,
-      minimizeToTray,
       canMinimizeToTray,
       classes,
+      minimizeToTray,
+      minimizeToTrayToggle,
+      notifyOnMinimizeToTray,
+      notifyOnMinimizeToTrayToggle,
     } = this.props
 
     return (
@@ -98,6 +102,19 @@ class _WindowsSettings extends Component<Props> {
               toggled={minimizeToTray}
               onToggle={minimizeToTrayToggle}
             />
+            {minimizeToTray && (
+              <>
+                <Divider />
+                <ToggleSetting
+                  title={'Notify on Close to Tray'}
+                  description={
+                    'Salad will use a Windows desktop notification to remind you when it hides in the tray and continues to run in the background.'
+                  }
+                  toggled={notifyOnMinimizeToTray}
+                  onToggle={notifyOnMinimizeToTrayToggle}
+                />
+              </>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
This fixes restoring the persisted "Close to Tray" option after Salad is closed & reopened.