### PR TITLE
Remove invalid T-Rex command line argument

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/getTrexRavencoinNiceHashDefinition.ts
+++ b/packages/web-app/src/modules/salad-bowl/definitions/getTrexRavencoinNiceHashDefinition.ts
@@ -13,7 +13,7 @@ export const getTrexRavencoinNiceHashDefinition = (nicehashAddress: string, mach
     downloadUrl:
       'https://github.com/SaladTechnologies/plugin-downloads/releases/download/trex0.16.1/t-rex-0-16-1-windows-cuda.zip',
     exe: 't-rex.exe',
-    args: `-a kawpow ${getServer('usa')} ${getUser(nicehashAddress, machine.minerId)} -w 0`,
+    args: `-a kawpow ${getServer('usa')} ${getUser(nicehashAddress, machine.minerId)}`,
     runningCheck: '(?:\\[ OK \\]|[1-9][0-9]*\\.\\d* (?:h|H|kh|kH|Kh|KH|mh|mH|Mh|MH))',
     initialTimeout: 600000,
     initialRetries: 1,


### PR DESCRIPTION
This removes an invalid `-w 0` command line argument that was being passed to T-Rex. The invalid argument caused T-Rex to print its help information and exit.