### PR TITLE
Move icon path definitions out from main.ts into icons.ts.

### DIFF
--- a/packages/desktop-app/src/icons.ts
+++ b/packages/desktop-app/src/icons.ts
@@ -5,8 +5,6 @@ declare const __static: string
 
 export const LOGO_PATH = path.join(__static, process.platform === 'win32' ? 'logo.ico' : 'logo.png')
 
-export const LOGO_ANIMATED_PATH = path.join(__static, 'logo.gif')
-
 export const TRAY_ICON_PATH = LOGO_PATH
 
 export const TRAY_ACTIVE_ICON_PATH = path.join(

--- a/packages/desktop-app/src/icons.ts
+++ b/packages/desktop-app/src/icons.ts
@@ -19,6 +19,11 @@ export const TRAY_ALERT_ICON_PATH = path.join(
   process.platform === 'win32' ? 'logo-alert.ico' : 'logo-alert.png',
 )
 
+// For MacOS Dock
+export const DOCK_LOGO_ACTIVE_PATH = path.join(__static, 'logo-active.png')
+// For MacOS Dock
+export const DOCK_LOGO_ALERT_PATH = path.join(__static, 'logo-alert.png')
+
 export const TASKBAR_OVERLAY_ACTIVE_PATH = path.join(__static, 'taskbar-overlay-active.png')
 
 export const NOTIFICATION_ICON_PATH = path.join(__static, 'logo.png')

--- a/packages/desktop-app/src/icons.ts
+++ b/packages/desktop-app/src/icons.ts
@@ -1,0 +1,24 @@
+import path from 'path'
+import process from 'process'
+
+declare const __static: string
+
+export const LOGO_PATH = path.join(__static, process.platform === 'win32' ? 'logo.ico' : 'logo.png')
+
+export const LOGO_ANIMATED_PATH = path.join(__static, 'logo.gif')
+
+export const TRAY_ICON_PATH = LOGO_PATH
+
+export const TRAY_ACTIVE_ICON_PATH = path.join(
+  __static,
+  process.platform === 'win32' ? 'logo-active.ico' : 'logo-active.png',
+)
+
+export const TRAY_ALERT_ICON_PATH = path.join(
+  __static,
+  process.platform === 'win32' ? 'logo-alert.ico' : 'logo-alert.png',
+)
+
+export const TASKBAR_OVERLAY_ACTIVE_PATH = path.join(__static, 'taskbar-overlay-active.png')
+
+export const NOTIFICATION_ICON_PATH = path.join(__static, 'logo.png')

--- a/packages/desktop-app/src/icons.ts
+++ b/packages/desktop-app/src/icons.ts
@@ -24,6 +24,6 @@ export const DOCK_LOGO_ACTIVE_PATH = path.join(__static, 'logo-active.png')
 // [Placeholder] For MacOS Dock
 export const DOCK_LOGO_ALERT_PATH = path.join(__static, 'logo-alert.png')
 
-export const TASKBAR_OVERLAY_ACTIVE_PATH = path.join(__static, 'taskbar-overlay-active.png')
+export const TAKSBAR_ACTIVE_OVERLAY_ICON_PATH = path.join(__static, 'taskbar-overlay-active.png')
 
 export const NOTIFICATION_ICON_PATH = path.join(__static, 'logo.png')

--- a/packages/desktop-app/src/icons.ts
+++ b/packages/desktop-app/src/icons.ts
@@ -19,9 +19,9 @@ export const TRAY_ALERT_ICON_PATH = path.join(
   process.platform === 'win32' ? 'logo-alert.ico' : 'logo-alert.png',
 )
 
-// For MacOS Dock
+// [Placeholder] For MacOS Dock
 export const DOCK_LOGO_ACTIVE_PATH = path.join(__static, 'logo-active.png')
-// For MacOS Dock
+// [Placeholder] For MacOS Dock
 export const DOCK_LOGO_ALERT_PATH = path.join(__static, 'logo-alert.png')
 
 export const TASKBAR_OVERLAY_ACTIVE_PATH = path.join(__static, 'taskbar-overlay-active.png')

--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -7,6 +7,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as si from 'systeminformation'
 import { Config } from './config'
+import * as icons from './icons'
 import * as Logger from './Logger'
 import { MachineInfo } from './models/MachineInfo'
 import { Profile } from './models/Profile'
@@ -136,7 +137,7 @@ const createOfflineWindow = () => {
     center: true,
     frame: false,
     height: 350,
-    icon: path.join(__static, 'logo.ico'),
+    icon: icons.LOGO_PATH,
     resizable: false,
     title: 'Salad',
     webPreferences: {
@@ -172,7 +173,7 @@ const createMainWindow = () => {
     backgroundColor: theme.darkBlue,
     center: true,
     frame: false,
-    icon: path.join(__static, 'logo.ico'),
+    icon: icons.LOGO_PATH,
     minHeight: 766,
     minWidth: 1216,
     show: false,
@@ -194,7 +195,7 @@ const createMainWindow = () => {
   })
 
   mainWindow.once('ready-to-show', () => {
-    tray = new Tray(path.join(__static, 'logo.ico'))
+    tray = new Tray(icons.TRAY_ICON_PATH)
     tray.setContextMenu(createSystemTrayMenu(true))
     tray.setToolTip('Salad')
     tray.on('double-click', () => {
@@ -210,6 +211,7 @@ const createMainWindow = () => {
     })
 
     mainWindow.show()
+
     if (offlineWindow) {
       offlineWindow.destroy()
     }
@@ -223,13 +225,13 @@ const createMainWindow = () => {
         activeIconEnabled = true
         if (mainWindow) {
           mainWindow.setOverlayIcon(
-            nativeImage.createFromPath(path.join(__static, 'taskbar-overlay-active.png')),
+            nativeImage.createFromPath(icons.TASKBAR_OVERLAY_ACTIVE_PATH),
             'Background Tasks Running',
           )
         }
 
         if (tray) {
-          tray.setImage(path.join(__static, 'logo-active.ico'))
+          tray.setImage(icons.TRAY_ACTIVE_ICON_PATH)
         }
       }
     } else {
@@ -240,7 +242,7 @@ const createMainWindow = () => {
         }
 
         if (tray) {
-          tray.setImage(path.join(__static, 'logo.ico'))
+          tray.setImage(icons.TRAY_ICON_PATH)
         }
       }
     }
@@ -354,7 +356,7 @@ const createMainWindow = () => {
     notifier.notify(
       {
         ...message,
-        icon: path.join(__static, 'logo.png'),
+        icon: icons.TRAY_ICON_PATH,
         appID: 'salad-technologies-desktop-app',
       },
       (err) => {

--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -5,6 +5,7 @@ import isOnline from 'is-online'
 import { WindowsToaster } from 'node-notifier'
 import * as os from 'os'
 import * as path from 'path'
+import process from 'process'
 import * as si from 'systeminformation'
 import { Config } from './config'
 import * as icons from './icons'
@@ -224,10 +225,16 @@ const createMainWindow = () => {
       if (!activeIconEnabled) {
         activeIconEnabled = true
         if (mainWindow) {
-          mainWindow.setOverlayIcon(
-            nativeImage.createFromPath(icons.TASKBAR_OVERLAY_ACTIVE_PATH),
-            'Background Tasks Running',
-          )
+          if (process.platform === 'win32') {
+            mainWindow.setOverlayIcon(
+              nativeImage.createFromPath(icons.TAKSBAR_ACTIVE_OVERLAY_ICON_PATH),
+              'Background Tasks Running',
+            )
+          } else if (process.platform === 'linux') {
+            // Placeholder for Linux-specific icon management
+          } else if (process.platform === 'darwin') {
+            // Placeholder for macOS-specific icon management
+          }
         }
 
         if (tray) {
@@ -238,7 +245,13 @@ const createMainWindow = () => {
       if (activeIconEnabled) {
         activeIconEnabled = false
         if (mainWindow) {
-          mainWindow.setOverlayIcon(null, '')
+          if (process.platform === 'win32') {
+            mainWindow.setOverlayIcon(null, '')
+          } else if (process.platform === 'linux') {
+            // Placeholder for Linux-specific icon management
+          } else if (process.platform === 'darwin') {
+            // Placeholder for macOS-specific icon management
+          }
         }
 
         if (tray) {

--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -356,7 +356,7 @@ const createMainWindow = () => {
     notifier.notify(
       {
         ...message,
-        icon: icons.TRAY_ICON_PATH,
+        icon: icons.NOTIFICATION_ICON_PATH,
         appID: 'salad-technologies-desktop-app',
       },
       (err) => {


### PR DESCRIPTION
As of https://trello.com/c/bz057Sg7/1-icon-compatibility

`icons.ts` uses the `process` module to check for platform. `.ico` files are used on win32 and `.png` for linux/darwin.