### PR TITLE
Inject Node.js platform name in preload.js (i.e. darwin, linux, win32)

### DIFF
--- a/packages/desktop-app/src/preload.js
+++ b/packages/desktop-app/src/preload.js
@@ -1,4 +1,5 @@
 const { ipcRenderer: ipc } = require('electron')
+const process = require('process')
 
 init()
 
@@ -17,7 +18,7 @@ function init() {
   console.log('Injecting Salad bridge')
 
   window.salad = {
-    platform: 'electron',
+    platform: process.platform,
     apiVersion: 8,
     dispatch: dispatch,
   }

--- a/packages/web-app/src/modules/machine/NativeStore.ts
+++ b/packages/web-app/src/modules/machine/NativeStore.ts
@@ -62,7 +62,14 @@ export class NativeStore {
 
   @computed
   get isNative(): boolean {
-    return window.salad && window.salad.platform === 'electron'
+    // The `electron` value is injected by older versions of the desktop application.
+    return (
+      window.salad &&
+      (window.salad.platform === 'electron' ||
+        window.salad.platform === 'darwin' ||
+        window.salad.platform === 'linux' ||
+        window.salad.platform === 'win32')
+    )
   }
 
   @computed


### PR DESCRIPTION
Replaces the `electron` value injected in preload.js with the actual Node.js platform value (i.e. `darwin`, `linux`, `win32`).