### PR TITLE
Linux gpu detection

### DIFF
--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -23,6 +23,7 @@ import * as icons from './icons'
 import * as Logger from './Logger'
 import { MachineInfo } from './models/MachineInfo'
 import { Profile } from './models/Profile'
+import { getLinuxGraphics } from './salad-bowl/linuxGPUDetector'
 import { PluginDefinition } from './salad-bowl/models/PluginDefinition'
 import { PluginStatus } from './salad-bowl/models/PluginStatus'
 import { PluginManager } from './salad-bowl/PluginManager'
@@ -78,7 +79,7 @@ const getMachineInfo = (): Promise<MachineInfo> => {
   return Promise.allSettled([
     si.cpu(),
     si.cpuFlags(),
-    si.graphics(),
+    process.platform === 'linux' ? getLinuxGraphics() : si.graphics(),
     si.memLayout(),
     si.osInfo(),
     si.services('*'),

--- a/packages/desktop-app/src/models/MachineInfo.ts
+++ b/packages/desktop-app/src/models/MachineInfo.ts
@@ -1,8 +1,9 @@
 import * as si from 'systeminformation'
+import { LinuxGraphicsData } from '../salad-bowl/models/LinuxGraphics'
 
 export interface MachineInfo {
   cpu?: si.Systeminformation.CpuData | si.Systeminformation.CpuWithFlagsData
-  graphics?: si.Systeminformation.GraphicsData
+  graphics?: si.Systeminformation.GraphicsData | LinuxGraphicsData
   memLayout?: si.Systeminformation.MemLayoutData[]
   os?: si.Systeminformation.OsData
   platform?: 'aix' | 'android' | 'cygwin' | 'darwin' | 'freebsd' | 'linux' | 'netbsd' | 'openbsd' | 'sunos' | 'win32'

--- a/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
+++ b/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
@@ -26,10 +26,10 @@ function getVramFromClinfo() {
         // Switch and store useful device information for each line in output
         switch (m[2]) {
           case 'CL_DEVICE_NAME':
-            controllers[m[1]]['name'] = m[3]
+            controllers[m[1]]['model'] = m[3]
             break
           case 'CL_DEVICE_BOARD_NAME_AMD':
-            controllers[m[1]]['name'] = m[3]
+            controllers[m[1]]['model'] = m[3]
             break
           case 'CL_DEVICE_VENDOR':
             controllers[m[1]]['vendor'] = m[3]
@@ -49,10 +49,19 @@ function getVramFromClinfo() {
 }
 
 export function getLinuxGraphics() {
-  return new Promise<LinuxGraphicsData>(function (resolve, reject) {
+  return new Promise<LinuxGraphicsData>(function (resolve) {
     Promise.allSettled([si.graphics(), getVramFromClinfo()]).then(([graphics, clinfoOutput]) => {
+      var controllerInfo = undefined
+
+      if (clinfoOutput.status === 'fulfilled' && controllerInfo === undefined) {
+        controllerInfo = clinfoOutput.value
+      }
+      if (graphics.status === 'fulfilled' && controllerInfo === undefined) {
+        controllerInfo = graphics.value.controllers
+      }
+
       resolve({
-        controllers: clinfoOutput.status === 'fulfilled' ? clinfoOutput.value : undefined,
+        controllers: controllerInfo,
         displays: graphics.status === 'fulfilled' ? graphics.value.displays : undefined,
       })
     })

--- a/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
+++ b/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
@@ -50,30 +50,33 @@ function getVramFromClinfo() {
 
 function getVramFromGlxinfo() {
   return new Promise<LinuxGraphicsController[]>((resolve, reject) => {
-    exec("glxinfo -B | egrep -i 'vendor|renderer|VBO free memory'", (err, stdout: string, stderr: string) => {
-      if (err) {
-        reject(err)
-      }
-      if (stderr) {
-        reject(err)
-      }
-      var device: LinuxGraphicsController = {}
-      stdout.split('\n').forEach((line) => {
-        try {
-          if (line.includes('renderer')) {
-            device['model'] = line.match('OpenGL renderer string: (.+)')![1]
-          }
-          if (line.includes('vendor')) {
-            device['vendor'] = line.match('OpenGL vendor string: (.+)')![1]
-          }
-          // VBO for AMD, Dedicated video memory for Nvidia
-          if (line.includes('VBO free memory') || line.includes('Dedicated video memory')) {
-            device['vram'] = parseInt(line.match(/\d+/)![0])
-          }
-        } catch (err) {}
-      })
-      resolve([device])
-    })
+    exec(
+      "glxinfo -B | egrep 'vendor|renderer|VBO free memory|Dedicated video memory:'",
+      (err, stdout: string, stderr: string) => {
+        if (err) {
+          reject(err)
+        }
+        if (stderr) {
+          reject(err)
+        }
+        var device: LinuxGraphicsController = {}
+        stdout.split('\n').forEach((line) => {
+          try {
+            if (line.includes('renderer')) {
+              device['model'] = line.match('OpenGL renderer string: (.+)')![1]
+            }
+            if (line.includes('vendor')) {
+              device['vendor'] = line.match('OpenGL vendor string: (.+)')![1]
+            }
+            // VBO for AMD, Dedicated video memory for Nvidia
+            if (line.includes('VBO free memory') || line.includes('Dedicated video memory')) {
+              device['vram'] = parseInt(line.match(/\d+/)![0])
+            }
+          } catch (err) {}
+        })
+        resolve([device])
+      },
+    )
   })
 }
 

--- a/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
+++ b/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
@@ -4,14 +4,14 @@ import { LinuxGraphicsController, LinuxGraphicsData } from './models/LinuxGraphi
 
 function getVramFromClinfo() {
   return new Promise<LinuxGraphicsController[]>(function (resolve, reject) {
-    exec('clinfo --raw', function (err: Error, stdout: string, stderr: string) {
+    exec('clinfo --raw', function (err, stdout: string, stderr: string) {
       if (err) {
         reject(err)
       }
       if (stderr) {
         reject(stderr)
       }
-      var regex = /\[\w+\/(\d+)\]\s*(\w+)\s*(.+)/gm
+      var regex = /\[(\w+\/\d+)\]\s*(\w+)\s*(.+)/gm
       var controllers: { [key: string]: LinuxGraphicsController } = {}
       var m
       while ((m = regex.exec(stdout))) {

--- a/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
+++ b/packages/desktop-app/src/salad-bowl/linuxGPUDetector.ts
@@ -1,0 +1,60 @@
+import { exec } from 'child_process'
+import * as si from 'systeminformation'
+import { LinuxGraphicsController, LinuxGraphicsData } from './models/LinuxGraphics'
+
+function getVramFromClinfo() {
+  return new Promise<LinuxGraphicsController[]>(function (resolve, reject) {
+    exec('clinfo --raw', function (err: Error, stdout: string, stderr: string) {
+      if (err) {
+        reject(err)
+      }
+      if (stderr) {
+        reject(stderr)
+      }
+      var regex = /\[\w+\/(\d+)\]\s*(\w+)\s*(.+)/gm
+      var controllers: { [key: string]: LinuxGraphicsController } = {}
+      var m
+      while ((m = regex.exec(stdout))) {
+        // This is necessary to avoid infinite loops with zero-width matches
+        if (m.index === regex.lastIndex) {
+          regex.lastIndex++
+        }
+        // Create a key - object pair for each unique GPU. Useful to differentiate between different GPUs.
+        if (!Object.keys(controllers).includes(m[1])) {
+          controllers[m[1]] = {}
+        }
+        // Switch and store useful device information for each line in output
+        switch (m[2]) {
+          case 'CL_DEVICE_NAME':
+            controllers[m[1]]['name'] = m[3]
+            break
+          case 'CL_DEVICE_BOARD_NAME_AMD':
+            controllers[m[1]]['name'] = m[3]
+            break
+          case 'CL_DEVICE_VENDOR':
+            controllers[m[1]]['vendor'] = m[3]
+            break
+          case 'CL_DRIVER_VERSION':
+            controllers[m[1]]['driverVersion'] = m[3]
+            break
+          case 'CL_DEVICE_GLOBAL_MEM_SIZE':
+            controllers[m[1]]['vram'] = Math.round(parseInt(m[3]) / 1024 / 1024)
+            break
+        }
+      }
+      // Output in a format similar to systeminformation for consistency
+      resolve(Object.values(controllers))
+    })
+  })
+}
+
+export function getLinuxGraphics() {
+  return new Promise<LinuxGraphicsData>(function (resolve, reject) {
+    Promise.allSettled([si.graphics(), getVramFromClinfo()]).then(([graphics, clinfoOutput]) => {
+      resolve({
+        controllers: clinfoOutput.status === 'fulfilled' ? clinfoOutput.value : undefined,
+        displays: graphics.status === 'fulfilled' ? graphics.value.displays : undefined,
+      })
+    })
+  })
+}

--- a/packages/desktop-app/src/salad-bowl/models/LinuxGraphics.ts
+++ b/packages/desktop-app/src/salad-bowl/models/LinuxGraphics.ts
@@ -2,7 +2,7 @@ import * as si from 'systeminformation'
 
 export interface LinuxGraphicsController {
   vendor?: string
-  name?: string
+  model?: string
   vram?: number
   driverVersion?: string
 }

--- a/packages/desktop-app/src/salad-bowl/models/LinuxGraphics.ts
+++ b/packages/desktop-app/src/salad-bowl/models/LinuxGraphics.ts
@@ -1,0 +1,13 @@
+import * as si from 'systeminformation'
+
+export interface LinuxGraphicsController {
+  vendor?: string
+  name?: string
+  vram?: number
+  driverVersion?: string
+}
+
+export interface LinuxGraphicsData {
+  controllers?: LinuxGraphicsController[]
+  displays?: si.Systeminformation.GraphicsDisplayData[]
+}


### PR DESCRIPTION
Add GPU detection for Linux using clinfo & glxinfo. If both of those fail, fall back to the default, systeminformation.