### PR TITLE
Add proper plugin stopping for linux platforms

### DIFF
--- a/packages/desktop-app/src/salad-bowl/Plugin.ts
+++ b/packages/desktop-app/src/salad-bowl/Plugin.ts
@@ -106,6 +106,13 @@ export class Plugin {
             execSync(`taskkill /im ${processName} /t /f`)
           } catch {}
         }, 200)
+      } else if (process.platform === 'linux') {
+        const processName = path.basename(this.pluginDefinition.exe)
+        setTimeout(() => {
+          try {
+            execSync(`pkill ${processName}`)
+          } catch {}
+        }, 200)
       }
     } else {
       console.log('No process to kill.')


### PR DESCRIPTION
Doing just this.process.kill() is not enough on linux to end miner process; use pkill to kill the process.