### PR TITLE
Explicitly disable PhoenixMiner logging on linux

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/linux/phoenixminer-ethash.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/linux/phoenixminer-ethash.tsx
@@ -18,7 +18,7 @@ export const createPhoenixMinerEthashPluginDefinitions = (accounts: Accounts): P
             algorithm: 'Ethash',
             downloadUrl: download.linuxUrl,
             exe: 'PhoenixMiner',
-            args: `-rmode 0 -rvram 1 ${pool}`,
+            args: `-rmode 0 -rvram 1 -log 0 ${pool}`,
             runningCheck: '(?:Share accepted|[1-9][0-9]*\\.\\d* (?:kh|kH|Kh|KH|mh|mH|Mh|MH)\\/s)',
             initialTimeout: 600000,
             initialRetries: 3,


### PR DESCRIPTION
add the `-log 0` arguments to explicitly disable logging.
without this, PhoenixMiner is logging to the users home directory