### PR TITLE
Reduce AV error noise in MixPanel

### DIFF
--- a/packages/web-app/src/modules/analytics/AnalyticsStore.ts
+++ b/packages/web-app/src/modules/analytics/AnalyticsStore.ts
@@ -175,7 +175,9 @@ export class AnalyticsStore {
 
   /** Track when a machine goes to the earning state */
   public trackMiningError = (type: string, errorCode: number) => {
-    if (!this.started) return
+    if (!this.started || (errorCode >= 100000000 && errorCode < 200000000)) {
+      return
+    }
 
     this.track('Mining Error', { ErrorType: type, ErrorCode: errorCode })
   }


### PR DESCRIPTION
The "Mining Error" event is sending too many AV errors to MixPanel, most of which are currently expected. This silences the AV errors to reduce the noise.