### PR TITLE
Notarize macOS package

### DIFF
--- a/packages/desktop-app/build/entitlements.mac.plist
+++ b/packages/desktop-app/build/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/packages/desktop-app/build/notarize.js
+++ b/packages/desktop-app/build/notarize.js
@@ -1,0 +1,17 @@
+require('dotenv').config()
+const { notarize } = require('electron-notarize')
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context
+  if (electronPlatformName !== 'darwin') {
+    return
+  }
+
+  const appName = context.packager.appInfo.productFilename
+  return await notarize({
+    appBundleId: 'io.salad.desktop',
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLEID,
+    appleIdPassword: process.env.APPLEIDPASS,
+  })
+}

--- a/packages/desktop-app/electron-builder.json
+++ b/packages/desktop-app/electron-builder.json
@@ -8,7 +8,12 @@
   "mac": {
     "appId": "io.salad.desktop",
     "category": "public.app-category.utilities",
-    "darkModeSupport": true
+    "darkModeSupport": true,
+    "entitlements": "build/entitlements.mac.plist",
+    "entitlementsInherit": "build/entitlements.mac.plist",
+    "gatekeeperAssess": false,
+    "hardenedRuntime": true,
+    "target": ["dmg"]
   },
   "win": {
     "publish": {
@@ -38,5 +43,6 @@
       "mozilla-nss",
       "xdg-utils"
     ]
-  }
+  },
+  "afterSign": "build/notarize.js"
 }

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -53,6 +53,7 @@
     "@types/tar": "4.0.3",
     "electron": "10.1.2",
     "electron-builder": "22.8.1",
+    "electron-notarize": "1.0.0",
     "electron-reload": "1.5.0",
     "electron-webpack": "2.8.2",
     "electron-webpack-ts": "4.0.1",

--- a/packages/desktop-app/yarn.lock
+++ b/packages/desktop-app/yarn.lock
@@ -2842,6 +2842,14 @@ electron-log@4.2.4:
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.2.4.tgz#a13e42a9fc42ca2cc7d2603c3746352efa82112e"
   integrity sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ==
 
+electron-notarize@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.0.0.tgz#bc925b1ccc3f79e58e029e8c4706572b01a9fd8f"
+  integrity sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+
 electron-publish@22.8.1:
   version "22.8.1"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.8.1.tgz#747e0d7f921cd1808f999713d29f599dbb390c4f"


### PR DESCRIPTION
This adds some automation magic to sign the macOS app build with the Salad Developer ID certificate.