### PR TITLE
Disable GPU mining on macOS

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/macos/xmrig-kawpow.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/macos/xmrig-kawpow.tsx
@@ -1,37 +1,34 @@
-import semver from 'semver'
 import { Accounts } from '../accounts'
-import { STANDARD_ERRORS } from '../errors'
 import { PluginDefinition } from '../plugin-definitions'
-import { hasGpu } from '../requirements'
-import { downloads } from '../xmrig'
 
-export const createXMRigKawPowPluginDefinitions = (accounts: Accounts): PluginDefinition[] =>
-  downloads
-    // XMRig support for KawPow added in v6.0.0.
-    .filter(({ version }) => {
-      const sv = semver.coerce(version)
-      return sv !== null && semver.gte(sv, '6.0.0')
-    })
-    .reduce((definitions, download) => {
-      const connection = (location: string) =>
-        `-o stratum+tcp://kawpow.${location}.nicehash.com:3385 -a kawpow -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
-
-      if (download.macOSUrl !== undefined) {
-        definitions.push({
-          name: 'XMRig',
-          version: download.version,
-          algorithm: 'KawPow',
-          downloadUrl: download.macOSUrl,
-          exe: 'xmrig',
-          args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
-          runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
-          initialTimeout: 600000,
-          initialRetries: 3,
-          watchdogTimeout: 900000,
-          errors: [...STANDARD_ERRORS],
-          requirements: [hasGpu('*', 3072)],
-        })
-      }
-
-      return definitions
-    }, [] as PluginDefinition[])
+export const createXMRigKawPowPluginDefinitions = (_accounts: Accounts): PluginDefinition[] => []
+  // TODO: Enable GPU mining on macOS
+  //// downloads
+  ////   // XMRig support for KawPow added in v6.0.0.
+  ////   .filter(({ version }) => {
+  ////     const sv = semver.coerce(version)
+  ////     return sv !== null && semver.gte(sv, '6.0.0')
+  ////   })
+  ////   .reduce((definitions, download) => {
+  ////     const connection = (location: string) =>
+  ////       `-o stratum+tcp://kawpow.${location}.nicehash.com:3385 -a kawpow -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
+  ////
+  ////     if (download.macOSUrl !== undefined) {
+  ////       definitions.push({
+  ////         name: 'XMRig',
+  ////         version: download.version,
+  ////         algorithm: 'KawPow',
+  ////         downloadUrl: download.macOSUrl,
+  ////         exe: 'xmrig',
+  ////         args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+  ////         runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+  ////         initialTimeout: 600000,
+  ////         initialRetries: 3,
+  ////         watchdogTimeout: 900000,
+  ////         errors: [...STANDARD_ERRORS],
+  ////         requirements: [hasGpu('*', 3072)],
+  ////       })
+  ////     }
+  ////
+  ////     return definitions
+  ////   }, [] as PluginDefinition[])

--- a/packages/web-app/src/modules/salad-bowl/definitions/macos/xmrig-randomx.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/macos/xmrig-randomx.tsx
@@ -1,7 +1,7 @@
 import { Accounts } from '../accounts'
 import { STANDARD_ERRORS } from '../errors'
 import { PluginDefinition } from '../plugin-definitions'
-import { hasCpu, hasGpu, not } from '../requirements'
+import { hasCpu } from '../requirements'
 import { downloads } from '../xmrig'
 
 export const createXMRigRandomXPluginDefinitions = (accounts: Accounts): PluginDefinition[] =>
@@ -10,20 +10,21 @@ export const createXMRigRandomXPluginDefinitions = (accounts: Accounts): PluginD
       `-o stratum+tcp://randomxmonero.${location}.nicehash.com:3380 --coin=monero -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
 
     if (download.macOSUrl !== undefined) {
-      definitions.push({
-        name: 'XMRig',
-        version: download.version,
-        algorithm: 'RandomX',
-        downloadUrl: download.macOSUrl,
-        exe: 'xmrig',
-        args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
-        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
-        initialTimeout: 600000,
-        initialRetries: 3,
-        watchdogTimeout: 900000,
-        errors: [...STANDARD_ERRORS],
-        requirements: [not(hasGpu('*', 4096)), hasGpu('*', 2048)],
-      })
+      // TODO: Enable GPU mining on macOS
+      //// definitions.push({
+      ////   name: 'XMRig',
+      ////   version: download.version,
+      ////   algorithm: 'RandomX',
+      ////   downloadUrl: download.macOSUrl,
+      ////   exe: 'xmrig',
+      ////   args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+      ////   runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+      ////   initialTimeout: 600000,
+      ////   initialRetries: 3,
+      ////   watchdogTimeout: 900000,
+      ////   errors: [...STANDARD_ERRORS],
+      ////   requirements: [not(hasGpu('*', 4096)), hasGpu('*', 2048)],
+      //// })
 
       definitions.push({
         name: 'XMRig-CPU',


### PR DESCRIPTION
Temporarily disables GPU mining on macOS. We just need more time to test. Currently, there are a lot of compatibility issues on our test machines.