### PR TITLE
Fix veggie module imports

### DIFF
--- a/packages/web-app/src/modules/xp-views/components/Pantry.tsx
+++ b/packages/web-app/src/modules/xp-views/components/Pantry.tsx
@@ -38,7 +38,7 @@ interface Props extends WithStyles<typeof styles> {
   currentXp?: number
 }
 
-const getImage = (key: string) => require(`../assets/${key}/complete.png`)
+const getImage = (key: string) => require(`../assets/${key}/complete.png`).default
 
 class _Pantry extends Component<Props> {
   getColumnPositions = (percent: number): number[] =>

--- a/packages/web-app/src/modules/xp-views/components/SlicedVeggie.tsx
+++ b/packages/web-app/src/modules/xp-views/components/SlicedVeggie.tsx
@@ -26,7 +26,7 @@ interface Props extends WithStyles<typeof styles> {
   percent?: number
 }
 
-const getImage = (key: string, slice: number) => require(`../assets/${key}/${slice}.svg`)
+const getImage = (key: string, slice: number) => require(`../assets/${key}/${slice}.svg`).default
 
 class _SlicedVeggie extends Component<Props> {
   getColumnPositions = (percent: number): number[] =>


### PR DESCRIPTION
The recent webpack loader/CRA updates changed the type of the module returned by a dynamic `require` to align with ES6 modules. The veggie URLs are now the `default` export of the module.