### PR TITLE
Update miners

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
@@ -2,6 +2,11 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '2.33',
+    linuxUrl: baseUrl + '/gminer-2.33/gminer-2-33-linux.tar.gz',
+    windowsUrl: baseUrl + '/gminer-2.33/gminer-2-33-windows.zip',
+  },
+  {
     version: '2.23',
     linuxUrl: baseUrl + '/gminer-2.23/gminer-2-23-linux.tar.gz',
     windowsUrl: baseUrl + '/gminer-2.23/gminer-2-23-windows.zip',
@@ -9,9 +14,5 @@ export const downloads = [
   {
     version: '2.21',
     windowsUrl: baseUrl + '/gminer2.21/gminer-2-21-windows.zip',
-  },
-  {
-    version: '2.15',
-    windowsUrl: baseUrl + '/gminer2.15/gminer-2-15-windows.zip',
   },
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/linux/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/linux/index.tsx
@@ -9,10 +9,10 @@ import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createLinuxPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
   ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createGMinerCuckooCyclePluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
   ...createXMRigKawPowPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
+  ...createGMinerCuckooCyclePluginDefinitions(accounts),
   ...createGMinerZHashPluginDefinitions(accounts),
   ...createXMRigRandomXPluginDefinitions(accounts),
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
@@ -2,6 +2,11 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '5.3b',
+    linuxUrl: baseUrl + '/phoenixminer-5-3b/phoenixminer-5-3b-linux.tar.gz',
+    windowsUrl: baseUrl + '/phoenixminer-5-3b/phoenixminer-5-3b-windows.zip',
+  },
+  {
     version: '5.1c',
     linuxUrl: baseUrl + '/phoenixminer-5-1-c/phoenixminer-5-1-c-linux.tar.gz',
     windowsUrl: baseUrl + '/phoenixminer-5-1-c/phoenixminer-5-1-c-windows.zip',
@@ -9,9 +14,5 @@ export const downloads = [
   {
     version: '5.0e',
     windowsUrl: baseUrl + '/phoenixminer-5-0-e/phoenixminer-5-0-e-windows.zip',
-  },
-  {
-    version: '4.9c',
-    windowsUrl: baseUrl + '/phoenixminer-4-9-c/phoenixminer-4-9-c-windows.zip',
   },
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
@@ -10,10 +10,10 @@ import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createWindowsPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
   ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createGMinerCuckooCyclePluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
   ...createXMRigKawPowPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
+  ...createGMinerCuckooCyclePluginDefinitions(accounts),
   ...createGMinerZHashPluginDefinitions(accounts),
   ...createXMRigRandomXPluginDefinitions(accounts),
   ...createCCminerLyra2REv3PluginDefinitions(accounts),

--- a/packages/web-app/src/modules/salad-bowl/definitions/xmrig.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/xmrig.tsx
@@ -2,6 +2,13 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '6.6.2',
+    linuxUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-linux.tar.gz',
+    macOSUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-macos.tar.gz',
+    windowsCudaUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-windows-cuda.zip',
+    windowsOpenCLUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-windows-opencl.zip',
+  },
+  {
     version: '6.3.3',
     linuxUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-linux.tar.gz',
     macOSUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-macos.tar.gz',
@@ -12,10 +19,5 @@ export const downloads = [
     version: '6.3.2',
     windowsCudaUrl: baseUrl + '/xmrig-6.3.2/xmrig-6.3.2-windows-cuda.zip',
     windowsOpenCLUrl: baseUrl + '/xmrig-6.3.2/xmrig-6.3.2-windows-opencl.zip',
-  },
-  {
-    version: '6.2.2',
-    windowsCudaUrl: baseUrl + '/xmrig-6.2.2/xmrig-6.2.2-windows-cuda.zip',
-    windowsOpenCLUrl: baseUrl + '/xmrig-6.2.2/xmrig-6.2.2-windows-opencl.zip',
   },
 ]


### PR DESCRIPTION
Adds PhoenixMiner  5.3b, GMiner 2.33, and XMRig 6.2.2. Notably, PhoenixMiner now supports the recent Ethereum Classic hard fork and Ethereum "zombie mining" (both enable Ethash mining on GPUs with 4GB of VRAM).