### PR TITLE
Disabled auto-reload on change of version

### DIFF
--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -112,7 +112,6 @@ export class RootStore {
         this.native.login(profile),
         this.referral.loadCurrentReferral(),
         this.referral.loadReferralCode(),
-        this.version.startVersionChecks(),
         this.refresh.refreshData(),
         this.zendesk.login(profile.username, profile.email),
       ])
@@ -127,7 +126,6 @@ export class RootStore {
       yield Promise.allSettled([
         this.analytics.trackLogout(),
         this.saladBowl.stop(StopReason.Logout),
-        this.version.stopVersionChecks(),
         this.native.logout(),
         this.zendesk.logout(),
       ])

--- a/packages/web-app/src/modules/versions/VersionStore.ts
+++ b/packages/web-app/src/modules/versions/VersionStore.ts
@@ -45,6 +45,8 @@ export class VersionStore {
       removeItem(VERSION_RELOAD_DATA)
     }
 
+    this.checkDesktopVersion()
+
     autorun(() => {
       console.log('Checking desktop version')
       if (this.latestDesktopVersion && this.store.native.desktopVersion) {


### PR DESCRIPTION
1. Removes logic that triggers auto-reload of app on new releases. 
2. Moves call of `checkDesktopVersion` from `startVersionChecks` to initialization of `VersionStore` class. 