### PR TITLE
Desktop version check and LogOut button fixes

### DIFF
--- a/packages/web-app/src/modules/settings-views/SettingsContainer.ts
+++ b/packages/web-app/src/modules/settings-views/SettingsContainer.ts
@@ -49,7 +49,8 @@ const mapStoreToProps = (store: RootStore): any => {
     appBuild: config.appBuild,
     latestDesktop: store.version.onLatestDesktop,
     onDownloadLatestDesktop: store.version.downloadLatestDesktop,
-    menuButtons: buttons,
+    menuButtons: store.auth.isAuthenticated ? buttons : [],
+    isAuthenticated: store.auth.isAuthenticated,
   }
 }
 

--- a/packages/web-app/src/modules/settings-views/SettingsContainer.ts
+++ b/packages/web-app/src/modules/settings-views/SettingsContainer.ts
@@ -50,7 +50,6 @@ const mapStoreToProps = (store: RootStore): any => {
     latestDesktop: store.version.onLatestDesktop,
     onDownloadLatestDesktop: store.version.downloadLatestDesktop,
     menuButtons: store.auth.isAuthenticated ? buttons : [],
-    isAuthenticated: store.auth.isAuthenticated,
   }
 }
 

--- a/packages/web-app/src/modules/versions/VersionStore.ts
+++ b/packages/web-app/src/modules/versions/VersionStore.ts
@@ -45,7 +45,9 @@ export class VersionStore {
       removeItem(VERSION_RELOAD_DATA)
     }
 
-    this.checkDesktopVersion()
+    if (this.store.native.isNative) {
+      this.checkDesktopVersion()
+    }
 
     autorun(() => {
       console.log('Checking desktop version')


### PR DESCRIPTION
1. Only shows LogOut button on Settings page if user is Authenticated
2. Only check desktop version if on the native app