### PR TITLE
Fix chart not showing up on mobile

### DIFF
--- a/packages/web-app/src/modules/earn-views/components/EarningChart.tsx
+++ b/packages/web-app/src/modules/earn-views/components/EarningChart.tsx
@@ -19,7 +19,7 @@ const styles = (theme: SaladTheme) => ({
   container: {
     display: 'flex',
     paddingTop: 75,
-    minHeight: 250,
+    height: 250,
     width: '100%',
     position: 'relative',
     flexDirection: 'column',


### PR DESCRIPTION
The minHeight property was not working on mobile, so I changed the chart back to absolute height. 