### PR TITLE
Add Cloudflare's privacy-focused web analytics

### DIFF
--- a/packages/web-app/public/index.html
+++ b/packages/web-app/public/index.html
@@ -41,5 +41,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "b56592a698d947b587a6c9c0f1ad61f6"}'></script>
   </body>
 </html>


### PR DESCRIPTION
It's all in the title. We'll get some usage analytics in aggregate form, respecting users' privacy. More details are available on [Cloudflare's website](https://www.cloudflare.com/web-analytics/).