### PR TITLE
Refactor config to .env files

### DIFF
--- a/packages/desktop-app/.env
+++ b/packages/desktop-app/.env
@@ -1,0 +1,1 @@
+ELECTRON_WEBPACK_APP_URL=https://app.salad.io

--- a/packages/desktop-app/.env.development
+++ b/packages/desktop-app/.env.development
@@ -1,0 +1,1 @@
+ELECTRON_WEBPACK_APP_URL=https://canary-app.salad.io/

--- a/packages/desktop-app/.gitignore
+++ b/packages/desktop-app/.gitignore
@@ -1,4 +1,6 @@
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
 release
-
-# Electron log files
 *.txt

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -23,7 +23,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "npm-run-all lint build-app build-installer",
+    "build": "cross-env NODE_ENV=production npm-run-all lint build-app build-installer",
     "build-and-publish-installer": "electron-builder --publish always",
     "build-app": "electron-webpack",
     "build-installer": "electron-builder",
@@ -31,8 +31,8 @@
     "lint": "npm-run-all --continue-on-error lint-ts lint-ts-unused",
     "lint-ts": "tsc --noEmit",
     "lint-ts-unused": "ts-unused-exports ./tsconfig.json",
-    "release": "npm-run-all lint build-app build-and-publish-installer",
-    "start": "electron-webpack dev"
+    "release": "cross-env NODE_ENV=production npm-run-all lint build-app build-and-publish-installer",
+    "start": "cross-env NODE_ENV=development electron-webpack dev"
   },
   "dependencies": {
     "@sentry/electron": "2.0.4",
@@ -51,6 +51,7 @@
     "@types/node": "14.14.17",
     "@types/node-notifier": "8.0.0",
     "@types/tar": "4.0.4",
+    "cross-env": "7.0.3",
     "electron": "10.2.0",
     "electron-builder": "22.9.1",
     "electron-notarize": "1.0.0",

--- a/packages/desktop-app/src/config.ts
+++ b/packages/desktop-app/src/config.ts
@@ -1,9 +1,4 @@
-class Config {
-  // public readonly appUrl: string = 'https://app.salad.io'
-  public readonly appUrl: string = 'https://canary-app.salad.io/'
-  // public readonly appUrl: string = 'http://localhost:3000/'
-}
-
-const instance = new Config()
-
-export { instance as Config }
+export const APP_URL =
+  typeof process.env.ELECTRON_WEBPACK_APP_URL === 'string' && process.env.ELECTRON_WEBPACK_APP_URL.length > 0
+    ? process.env.ELECTRON_WEBPACK_APP_URL
+    : 'http://localhost:3000'

--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -19,7 +19,7 @@ import * as os from 'os'
 import * as path from 'path'
 import process from 'process'
 import * as si from 'systeminformation'
-import { Config } from './config'
+import { APP_URL } from './config'
 import * as icons from './icons'
 import * as Logger from './Logger'
 import { MachineInfo } from './models/MachineInfo'
@@ -233,7 +233,7 @@ const createMainWindow = () => {
     width: 1216,
   })
 
-  mainWindow.loadURL(Config.appUrl)
+  mainWindow.loadURL(APP_URL)
   mainWindow.on('close', () => app.quit())
 
   mainWindow.webContents.on('before-input-event', (_: any, input: Input) => {

--- a/packages/desktop-app/yarn.lock
+++ b/packages/desktop-app/yarn.lock
@@ -2440,6 +2440,13 @@ crocket@^0.9.11:
   dependencies:
     xpipe "*"
 
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2450,6 +2457,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 cross-unzip@0.0.2:
   version "0.0.2"
@@ -5573,6 +5589,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -6447,10 +6468,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
   version "1.7.2"
@@ -7509,7 +7542,7 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.2:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
Support for `.env` files was already available in `electron-webpack`. It is configured to behave similarly to `create-react-app`, including variable expansion. The files loaded include:

- `.env`
- `.env.local`
- `.env.{NODE_ENV}`
- `.env.{NODE_ENV}.local`