### PR TITLE
Fix Linux package dependencies

### DIFF
--- a/packages/desktop-app/build/license_en.txt
+++ b/packages/desktop-app/build/license_en.txt
@@ -1,0 +1,100 @@
+End User License Agreement
+
+Important-read carefully: this end user license agreement ("EULA") is a legal agreement between you (either an individual or a legal entity) and Salad Technologies, Inc. For purposes of this EULA, "software" means the software program distributed, published or otherwise made available by Salad including, but not limited to the software mining program known as "Salad". Software also includes updates and upgrades as well as accompanying manual(s), packaging and other written files, electronic or online materials or documentation, and any and all copies of such software and associated materials. The software is copyrighted and licensed (not sold) to you. Use of the software is subject to the terms and conditions of this EULA, and any use of the software outside of the scope of such terms and conditions is prohibited. By clicking on the "accept" button or the respective checkbox at the end of this document or by downloading, installing, copying, running or otherwise using the software, you acknowledge that you have read this EULA, understand it and agree to be solely bound by its terms and conditions. If you do not accept the terms of this EULA, do not install, use or access the software and if already downloaded promptly dispose of the software. If you are using the Software in your capacity as employee or agent of a company or organization, then any references to the "Licensee" or "You" in this EULA shall refer to such entity and not to you in your personal capacity. You warrant that you are authorized to legally bind the Licensee. If you are not so authorized, then neither you nor the Licensee may use the Software in any manner whatsoever.
+
+Grant of Limited License.
+
+1.1. Limited Software License.
+
+Subject to the terms and conditions of this EULA, Salad hereby grants you a limited, non-exclusive, non-transferable, non-sublicensable, personal license to install, run and use a single copy of the Software for your personal use in the manner permitted by this EULA. The rights granted herein are subject to your compliance with this EULA.
+
+1.2. License Term.
+
+The term of your license under this EULA shall commence on the date that you accept this EULA and end on the earlier date of either your removal of the Software or Salad's termination of this EULA as detailed herein. Your license shall terminate immediately if you attempt to circumvent any technical protection measures used in connection with the Software and/or services or you otherwise use the Software and/or services in breach of the terms of this EULA.
+
+2.0. Reservation of Rights.
+
+Nothing in this EULA shall be deemed to grant you, either directly or by implication, estoppel, or otherwise any license or right other than those expressly granted in Section 1.1 of this EULA. By virtue of this EULA, you acquire only the right to use the Software and not any other right or ownership interest. Salad hereby retains all right, title and interest in and to the Software, including, but not limited to, all copyrights, trademarks, trade secrets, trade names, proprietary rights, patents, titles, computer codes, audiovisual effects, themes, settings, artwork and moral rights, whether or not registered, and all applications thereof. The Software is protected by applicable laws and treaties throughout the world. Unless expressly authorized by mandatory legislation, the Software may not be copied, reproduced or distributed in any manner or medium, in whole or in part, without prior written consent from Salad. All rights not expressly granted to you herein are reserved by Salad.
+
+3.0. Updates.
+
+Any software updates provided by Salad that updates or supplements the original Software are governed by this EULA unless separate license terms are provided with such updates or supplements that explicitly override this EULA, in which case, such separate terms will govern.
+
+4.0. License Limitations.
+
+Salad reserves all rights not expressly granted to you in this EULA. Without limiting the foregoing, you shall not authorize or permit any third party to: (a) use the Software for any purpose; (b) license, distribute, lease, rent, lend, transfer, assign or otherwise dispose of the Software; (c) reverse engineer, decompile, disassemble or otherwise attempt to discover the source code of or any trade secrets related to the Software; (d) reverse engineer, decompile, disassemble, translate, prepare derivative works based on or otherwise modify the Software, in whole or in part; (e) remove, alter or obscure any copyright notice or other proprietary rights notice on the Software; (f) make the Software publicly available or available on a network for use or download by multiple users; or (g) circumvent or attempt to circumvent any methods employed by Salad to control access to the components, features or functions of the Software.
+
+5.0. Open Source.
+
+The Software may contain components licensed to Salad under the GNU General Public License ("GPL Components"), currently available at <http://www.gnu.org/licenses/gpl.html>. The terms of the GPL will govern solely with respect to the GPL Components of the Software to the extent that this EULA conflicts with the requirements of the GPL and, in such event, you agree to be bound by the GPL with respect to your use of such components.
+
+6.0. Ownership.
+
+The Software is a valuable property of Salad and its licensors, protected by copyright and other intellectual property laws and treaties. Salad or its licensors own all rights, titles and interests in and to the Software, including but not limited to copyright and any other intellectual property rights.
+
+7.0. No Warranty.
+
+7.1. NO WARRANTY: YOU EXPRESSLY ACKNOWLEDGE AND AGREE THAT USE OF THE LICENSED APPLICATION IS AT YOUR SOLE RISK AND THAT THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED APPLICATION AND ANY SERVICES PERFORMED OR PROVIDED BY THE LICENSED APPLICATION ARE PROVIDED "AS IS" AND "AS AVAILABLE", WITH ALL FAULTS AND WITHOUT WARRANTY OF ANY KIND, AND LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS WITH RESPECT TO THE LICENSED APPLICATION AND ANY SERVICES, EITHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES AND/OR CONDITIONS OF MERCHANTABILITY, OF SATISFACTORY QUALITY, OF FITNESS FOR A PARTICULAR PURPOSE, OF ACCURACY, OF QUIET ENJOYMENT, AND OF NONINFRINGEMENT OF THIRD-PARTY RIGHTS. LICENSOR DOES NOT WARRANT AGAINST INTERFERENCE WITH YOUR ENJOYMENT OF THE LICENSED APPLICATION, THAT THE FUNCTIONS CONTAINED IN OR SERVICES PERFORMED OR PROVIDED BY THE LICENSED APPLICATION WILL MEET YOUR REQUIREMENTS, THAT THE OPERATION OF THE LICENSED APPLICATION OR SERVICES WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT DEFECTS IN THE LICENSED APPLICATION OR SERVICES WILL BE CORRECTED. NO ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY LICENSOR OR ITS AUTHORIZED REPRESENTATIVE SHALL CREATE A WARRANTY. SHOULD THE LICENSED APPLICATION OR SERVICES PROVE DEFECTIVE, YOU ASSUME THE ENTIRE COST OF ALL NECESSARY SERVICING, REPAIR, OR CORRECTION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES OR LIMITATIONS ON APPLICABLE STATUTORY RIGHTS OF A CONSUMER, SO THE ABOVE EXCLUSION AND LIMITATIONS MAY NOT APPLY TO YOU.
+
+8.0. Disclaimer of Certain Damages.
+
+IN NO EVENT WILL SALAD BE LIABLE FOR ANY INCIDENTAL, INDIRECT, SPECIAL, PUNITIVE, CONSEQUENTIAL OR SIMILAR DAMAGES OR LIABILITIES WHATSOEVER (INCLUDING, BUT NOT LIMITED TO LOSS OF DATA, INFORMATION, REVENUE, PROFIT OR BUSINESS) ARISING OUT OF OR RELATING TO THE USE OF OR INABILITY TO USE THE SOFTWARE OR OTHERWISE UNDER OR IN CONNECTION WITH THIS EULA OR THE SOFTWARE, WHETHER BASED ON CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHER THEORY EVEN IF SALAD HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+9.0. Limitation of Liability.
+
+9.1. IN NO EVENT WILL SALAD OR ANY OF SALAD'S AFFILIATES, BE LIABLE FOR SPECIAL, INCIDENTAL, PUNITIVE, INDIRECT OR CONSEQUENTIAL DAMAGES OR LIABILITIES RESULTING FROM POSSESSION, ACCESS, MALFUNCTION, USE OF, OR INABILITY TO USE, THE SOFTWARE, INCLUDING, BUT NOT LIMITED TO, DAMAGES TO PROPERTY, LOSS OF GOODWILL, COMPUTER FAILURE OR MALFUNCTION AND, TO THE EXTENT PERMITTED BY LAW, DAMAGES FOR PERSONAL INJURIES, PROPERTY DAMAGE, LOST PROFITS OR PUNITIVE DAMAGES FROM ANY CAUSES OF ACTION ARISING OUT OF OR RELATED TO THIS EULA OR THE SOFTWARE, WHETHER ARISING IN TORT (INCLUDING NEGLIGENCE), CONTRACT, STRICT LIABILITY OR OTHERWISE AND WHETHER OR NOT SALAD AND SALAD'S AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. FOR PURPOSES OF THIS SECTION, SALAD'S AFFILIATES ARE THIRD PARTY BENEFICIARIES TO THE LIMITATIONS OF LIABILITY SPECIFIED HEREIN AND THEY MAY ENFORCE THIS EULA AGAINST YOU.
+
+9.2. IN NO EVENT SHALL SALAD'S OR SALAD'S AFFILIATES' LIABILITY FOR ANY DAMAGES (EXCEPT AS REQUIRED BY APPLICABLE LAW) EXCEED THE ACTUAL PRICE PAID BY YOU FOR USE OF THE SALAD SOFTWARE OR FIVE US DOLLARS (US $5), WHICHEVER LESS.
+
+9.3. SINCE SOME STATES AND COUNTRIES DO NOT ALLOW CERTAIN LIMITATIONS OF LIABILITY, THE LIMITATION OF LIABILITY DETAILED ABOVE SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+
+10.0. Indemnification.
+
+Licensee shall immediately upon demand indemnify and hold harmless Salad, Salad Affiliates and their officers, directors, employees, agents, representatives, subsidiaries and affiliates, from and against any and all claims, demands, damages, liabilities, losses and expenses (including without limitation all attorneys' fees, costs and expenses) of any kind whatsoever, arising directly or indirectly out of any representation, action or omission by you in using the Software or resulting from your breach of this EULA.
+
+11.0. Termination.
+
+Without prejudice to any other rights, Salad may terminate this EULA without further obligation or liability hereunder at its discretion upon 30 days prior notice, immediately if you do not abide by the terms and conditions contained herein, upon regulatory demand or upon advice provided by Salad's legal counsel. In such event, you must cease use of the Software and destroy all copies of the Software and all of its component parts.
+
+12.0. Rights and Obligations Upon Termination.
+
+Upon expiration or termination of this EULA, all rights granted to you hereunder shall cease and you shall promptly purge all copies of the Software or any portion thereof from all machines and/or other computer storage devices or media. The provisions of Sections 6, 7, 8, 9 and 10 of this EULA shall survive any termination or expiration of this EULA.
+
+13.0. Assignment.
+
+You may not transfer or assign your rights under this EULA to any third party. Any such transfer or assignment in violation of the foregoing restriction will be void. Salad may assign its rights under this EULA to any third party at its own discretion.
+
+14.0. Affiliates.
+
+For purposes of this EULA, an "Affiliate" of Salad means any legal entity that shares directly or indirectly ownership of 50% or more of the nominal value of the issued membership interest or more than 50% of the membership interest entitling the holders to vote for the election of the members of the managers or persons performing similar functions.
+
+15.0. Applicable Law.
+
+This EULA is governed by and construed in accordance with the laws of the State of Delaware without regard to any conflict of law principles to the contrary.
+
+16.0. Dispute Resolution.
+
+Any dispute, controversy or claim arising out of or relating to this EULA will be resolved exclusively and finally by confidential arbitration conducted by three neutral arbitrators in accordance with the procedures of the State of Delaware Arbitration Law and related enforcement rules. In such cases, the arbitration will be limited solely to the dispute between you and Salad. The arbitration, or any portion of it, will not be consolidated with any other arbitration and will not be conducted on a class-wide or class action basis. The arbitration shall take place in State of Delaware, and the arbitration proceedings shall be conducted in English. The arbitration award shall be final and binding on the parties and may be enforced in any court having jurisdiction. Nothing in this Section shall be deemed to prohibit or restrict Salad from seeking injunctive relief or seeking such other rights and remedies as it may have at law or equity for any actual or threatened breach of any provision of this EULA relating to Salad's intellectual property rights.
+
+17.0. Severability.
+
+If any provision of this EULA is held by a court of competent jurisdiction to be invalid, illegal, or unenforceable, the remainder of this EULA will remain in full force and effect.
+
+18.0. Entire Agreement.
+
+This EULA sets forth the entire agreement of Salad and you with respect to the subject matter hereof and supersedes all prior and contemporaneous understandings and agreements whether written or oral. No amendment, modification or waiver of any of the provisions of this EULA will be valid unless set forth in a written instrument signed by the party to be bound thereby.
+
+19.0. Salad Account.
+
+To use the Platform, you must register, or have previously registered, a Salad account (an "Account"). Creation and use of Accounts are subject to the following terms and conditions:
+
+- You may establish an Account only if: (i) you are a "natural person" and an adult in your country of residence (Corporations, Limited Liability Companies, partnerships and other legal or business entities may not establish an Account); and (ii) you are not an individual specifically prohibited by Salad from using any of our applications.
+- Salad might require you to provide accurate and up to date information that is personal to you, such as your name, address, phone number, and email address. Additionally, you might be required to verify your personal details with legal documents such as driver license, passport or similar document at any point in time or your account and balance might be frozen until verified. Salad shall also have the right to obtain non personal data from your connection to Salad.
+
+20.0 Salad Balance.
+
+As an active Account holder, you may participate in the Salad Rewards service ("Salad"). Salad Balance can only be used to obtain certain products and services offered by Salad; it has no cash value. Salad grants you a limited license to acquire, use, and redeem Salad Balance pursuant to the terms of this Agreement. Regardless of how it is acquired, Salad Balance is non-transferable to another person or Account, does not accrue interest, is not insured by the Federal Deposit Insurance Corporation (FDIC), and, unless otherwise required by law or permitted by this Agreement, is not redeemable or refundable for any sum of money or monetary value from Salad at any time. Salad Balance does not constitute or confer upon you any personal property right. Salad Balance is not a bank account. You are not allowed to have more than one account with Salad Balance. Salad reserves the right to expire a Salad Balance after 1 year (365 days) of inactivity of an account.
+
+21.0. Modification.
+
+Salad reserves the right, at its discretion, to change, modify, add/or remove portions of this EULA by posting the updated EULA on Salad's website. You will be deemed to have accepted such changes by continuing to use the Salad Software. If any provision of this EULA is held to be unenforceable for any reason, such provision shall be reformed only to the extent necessary to make it enforceable and the remaining provisions of this EULA shall not be affected.

--- a/packages/desktop-app/build/opensuse.patch
+++ b/packages/desktop-app/build/opensuse.patch
@@ -1,0 +1,19 @@
+diff --git a/packages/desktop-app/electron-builder.json b/packages/desktop-app/electron-builder.json
+index 6755db9..cf9f5fa 100644
+--- a/packages/desktop-app/electron-builder.json
++++ b/packages/desktop-app/electron-builder.json
+@@ -56,10 +56,10 @@
+       "at-spi2-core",
+       "gtk3",
+       "libXScrnSaver",
+-      "libXtst",
+-      "libnotify",
+-      "libuuid",
+-      "nss",
++      "libXtst6",
++      "libnotify4",
++      "libuuid1",
++      "mozilla-nss",
+       "xdg-utils",
+       "clinfo"
+     ]

--- a/packages/desktop-app/electron-builder.json
+++ b/packages/desktop-app/electron-builder.json
@@ -33,20 +33,35 @@
     "oneClick": false
   },
   "linux": {
-    "target": ["rpm", "deb", "snap"],
+    "target": ["rpm", "deb"],
     "category": "Utility"
+  },
+  "deb": {
+    "depends": [
+      "libgtk-3-0",
+      "libnotify4",
+      "libnss3",
+      "libxss1",
+      "libxtst6",
+      "xdg-utils",
+      "libatspi2.0-0",
+      "libuuid1",
+      "libappindicator3-1",
+      "libsecret-1-0",
+      "clinfo"
+    ]
   },
   "rpm": {
     "depends": [
       "at-spi2-core",
       "gtk3",
-      "libappindicator1",
-      "libnotify",
-      "libXtst6",
       "libXScrnSaver",
-      "libuuid-devel",
-      "mozilla-nss",
-      "xdg-utils"
+      "libXtst",
+      "libnotify",
+      "libuuid",
+      "nss",
+      "xdg-utils",
+      "clinfo"
     ]
   },
   "afterSign": "build/notarize.js"


### PR DESCRIPTION
Fixes the Ubuntu, Fedora, and openSUSE dependencies. `electron-builder` doesn't allow for two different `rpm` package definitions. This includes a `.patch` file that changes the `rpm` package dependencies from those required for Fedora (default) to those required for openSUSE.