### PR TITLE
Add tracking event for g2a redemptions being processed

### DIFF
--- a/packages/web-app/src/modules/analytics/AnalyticsStore.ts
+++ b/packages/web-app/src/modules/analytics/AnalyticsStore.ts
@@ -226,10 +226,11 @@ export class AnalyticsStore {
   }
 
   /** Track when a reward is redeemed */
-  public trackRewardRedeemed = (reward: Reward) => {
+  public trackRewardRedeemed = (reward: Reward, inProcess?: boolean) => {
     if (!this.started) return
 
-    this.track('Reward Redeemed', {
+    const trackingEvent = inProcess ? 'Reward Redemption In Process' : 'Reward Redeemed'
+    this.track(trackingEvent, {
       RewardId: reward.id,
       RewardName: reward.name,
       RewardPrice: reward.price,

--- a/packages/web-app/src/modules/reward/RewardStore.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.ts
@@ -290,6 +290,7 @@ export class RewardStore {
       if (!(error instanceof AbortError)) {
         //Hack since we getting tons of false negatives during redemptions
         if (error.message === timeoutMessage) {
+          this.store.analytics.trackRewardRedeemed(reward, true)
           //Show an order processing notification
           this.store.notifications.sendNotification({
             title: `Your order is being processed.`,


### PR DESCRIPTION
Currently adding an alternative tracking event to try and catch redemptions that are taking time to be processed with G2A. 