### PR TITLE
Update PhoenixMiner and GMiner and upgrade for Grin hardfork

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
@@ -2,6 +2,11 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '2.44',
+    linuxUrl: baseUrl + '/gminer-2.44/gminer-2-44-linux.tar.gz',
+    windowsUrl: baseUrl + '/gminer-2.44/gminer-2-44-windows.zip',
+  },
+  {
     version: '2.39',
     linuxUrl: baseUrl + '/gminer-2.39/gminer-2-39-linux.tar.gz',
     windowsUrl: baseUrl + '/gminer-2.39/gminer-2-39-windows.zip',
@@ -10,10 +15,5 @@ export const downloads = [
     version: '2.33',
     linuxUrl: baseUrl + '/gminer-2.33/gminer-2-33-linux.tar.gz',
     windowsUrl: baseUrl + '/gminer-2.33/gminer-2-33-windows.zip',
-  },
-  {
-    version: '2.23',
-    linuxUrl: baseUrl + '/gminer-2.23/gminer-2-23-linux.tar.gz',
-    windowsUrl: baseUrl + '/gminer-2.23/gminer-2-23-windows.zip',
   },
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
@@ -2,6 +2,11 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '5.5c',
+    linuxUrl: baseUrl + '/phoenixminer-5-5c/phoenixminer-5-5c-linux.tar.gz',
+    windowsUrl: baseUrl + '/phoenixminer-5-5c/phoenixminer-5-5c-windows.zip',
+  },
+  {
     version: '5.4c',
     linuxUrl: baseUrl + '/phoenixminer-5-4c/phoenixminer-5-4c-linux.tar.gz',
     windowsUrl: baseUrl + '/phoenixminer-5-4c/phoenixminer-5-4c-windows.zip',
@@ -10,10 +15,5 @@ export const downloads = [
     version: '5.3b',
     linuxUrl: baseUrl + '/phoenixminer-5-3b/phoenixminer-5-3b-linux.tar.gz',
     windowsUrl: baseUrl + '/phoenixminer-5-3b/phoenixminer-5-3b-windows.zip',
-  },
-  {
-    version: '5.1c',
-    linuxUrl: baseUrl + '/phoenixminer-5-1-c/phoenixminer-5-1-c-linux.tar.gz',
-    windowsUrl: baseUrl + '/phoenixminer-5-1-c/phoenixminer-5-1-c-windows.zip',
   },
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/gminer-cuckoocycle.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/gminer-cuckoocycle.tsx
@@ -1,4 +1,3 @@
-import semver from 'semver'
 import { Accounts } from '../accounts'
 import { STANDARD_ERRORS } from '../errors'
 import { downloads } from '../gminer'
@@ -6,32 +5,26 @@ import { PluginDefinition } from '../plugin-definitions'
 import { hasGpu } from '../requirements'
 
 export const createGMinerCuckooCyclePluginDefinitions = (accounts: Accounts): PluginDefinition[] =>
-  downloads
-    // GMiner support for cuckARooz29 added in v2.17.
-    .filter(({ version }) => {
-      const sv = semver.coerce(version)
-      return sv !== null && semver.gte(sv, '2.17.0')
-    })
-    .reduce((definitions, download) => {
-      const connection = (location: string) =>
-        `-s cuckarooz29.${location}.nicehash.com -n 3388 -u ${accounts.nicehash.address}.${accounts.nicehash.rigId}`
+  downloads.reduce((definitions, download) => {
+    const connection = (location: string) =>
+      `-s cuckoocycle.${location}.nicehash.com -n 3376 -u ${accounts.nicehash.address}.${accounts.nicehash.rigId}`
 
-      if (download.windowsUrl !== undefined) {
-        definitions.push({
-          name: 'GMiner',
-          version: download.version,
-          algorithm: 'cuckARooz29',
-          downloadUrl: download.windowsUrl,
-          exe: 'miner.exe',
-          args: `-a cuckarooz29 ${connection('usa')} ${connection('eu')} -w 0`,
-          runningCheck: '(?:Share Accepted|[1-9][0-9]*\\.\\d* G\\/s)',
-          initialTimeout: 600000,
-          initialRetries: 1,
-          watchdogTimeout: 900000,
-          errors: [...STANDARD_ERRORS],
-          requirements: [hasGpu('*', 4608)],
-        })
-      }
+    if (download.windowsUrl !== undefined) {
+      definitions.push({
+        name: 'GMiner',
+        version: download.version,
+        algorithm: 'CuckooCycle',
+        downloadUrl: download.windowsUrl,
+        exe: 'miner.exe',
+        args: `-a cuckoo ${connection('usa')} ${connection('eu')} -w 0`,
+        runningCheck: '(?:Share Accepted|[1-9][0-9]*\\.\\d* G\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 1,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [hasGpu('*', 4608)],
+      })
+    }
 
-      return definitions
-    }, [] as PluginDefinition[])
+    return definitions
+  }, [] as PluginDefinition[])


### PR DESCRIPTION
Updates to PhoenixMiner 5.5c. Updates to GMiner 2.44. Upgrades the plugin definition configuration to support the latest Grin hardfork.