### PR TITLE
Update GMiner and XMRig plugin definitions

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/gminer.tsx
@@ -2,6 +2,11 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '2.54',
+    linuxUrl: baseUrl + '/gminer-2.54/gminer-2-54-linux.tar.gz',
+    windowsUrl: baseUrl + '/gminer-2.54/gminer-2-54-windows.zip',
+  },
+  {
     version: '2.44',
     linuxUrl: baseUrl + '/gminer-2.44/gminer-2-44-linux.tar.gz',
     windowsUrl: baseUrl + '/gminer-2.44/gminer-2-44-windows.zip',
@@ -10,10 +15,5 @@ export const downloads = [
     version: '2.39',
     linuxUrl: baseUrl + '/gminer-2.39/gminer-2-39-linux.tar.gz',
     windowsUrl: baseUrl + '/gminer-2.39/gminer-2-39-windows.zip',
-  },
-  {
-    version: '2.33',
-    linuxUrl: baseUrl + '/gminer-2.33/gminer-2-33-linux.tar.gz',
-    windowsUrl: baseUrl + '/gminer-2.33/gminer-2-33-windows.zip',
   },
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-kawpow.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-kawpow.tsx
@@ -1,4 +1,3 @@
-import semver from 'semver'
 import { Accounts } from '../accounts'
 import { STANDARD_ERRORS } from '../errors'
 import { PluginDefinition } from '../plugin-definitions'
@@ -6,49 +5,60 @@ import { hasGpu } from '../requirements'
 import { downloads } from '../xmrig'
 
 export const createXMRigKawPowPluginDefinitions = (accounts: Accounts): PluginDefinition[] =>
-  downloads
-    // XMRig support for KawPow added in v6.0.0.
-    .filter(({ version }) => {
-      const sv = semver.coerce(version)
-      return sv !== null && semver.gte(sv, '6.0.0')
-    })
-    .reduce((definitions, download) => {
-      const connection = (location: string) =>
-        `-o stratum+tcp://kawpow.${location}.nicehash.com:3385 -a kawpow -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
+  downloads.reduce((definitions, download) => {
+    const connection = (location: string) =>
+      `-o stratum+tcp://kawpow.${location}.nicehash.com:3385 -a kawpow -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
 
-      if (download.windowsCudaUrl !== undefined) {
-        definitions.push({
-          name: 'XMRig',
-          version: download.version,
-          algorithm: 'KawPow',
-          downloadUrl: download.windowsCudaUrl,
-          exe: 'xmrig.exe',
-          args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
-          runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
-          initialTimeout: 600000,
-          initialRetries: 3,
-          watchdogTimeout: 900000,
-          errors: [...STANDARD_ERRORS],
-          requirements: [hasGpu('cuda', 3072)],
-        })
-      }
+    if (download.windowsUrl !== undefined) {
+      definitions.push({
+        name: 'XMRig',
+        version: download.version,
+        algorithm: 'KawPow',
+        downloadUrl: download.windowsUrl,
+        exe: 'xmrig.exe',
+        args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 3,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [hasGpu('*', 3072)],
+      })
+    }
 
-      if (download.windowsOpenCLUrl !== undefined) {
-        definitions.push({
-          name: 'XMRig',
-          version: download.version,
-          algorithm: 'KawPow',
-          downloadUrl: download.windowsOpenCLUrl,
-          exe: 'xmrig.exe',
-          args: `--no-cpu --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
-          runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
-          initialTimeout: 600000,
-          initialRetries: 3,
-          watchdogTimeout: 900000,
-          errors: [...STANDARD_ERRORS],
-          requirements: [hasGpu('opencl', 3072)],
-        })
-      }
+    if (download.windowsCudaUrl !== undefined) {
+      definitions.push({
+        name: 'XMRig',
+        version: download.version,
+        algorithm: 'KawPow',
+        downloadUrl: download.windowsCudaUrl,
+        exe: 'xmrig.exe',
+        args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 3,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [hasGpu('cuda', 3072)],
+      })
+    }
 
-      return definitions
-    }, [] as PluginDefinition[])
+    if (download.windowsOpenCLUrl !== undefined) {
+      definitions.push({
+        name: 'XMRig',
+        version: download.version,
+        algorithm: 'KawPow',
+        downloadUrl: download.windowsOpenCLUrl,
+        exe: 'xmrig.exe',
+        args: `--no-cpu --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 3,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [hasGpu('opencl', 3072)],
+      })
+    }
+
+    return definitions
+  }, [] as PluginDefinition[])

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-randomx.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-randomx.tsx
@@ -9,6 +9,38 @@ export const createXMRigRandomXPluginDefinitions = (accounts: Accounts): PluginD
     const connection = (location: string) =>
       `-o stratum+tcp://randomxmonero.${location}.nicehash.com:3380 --coin=monero -u ${accounts.nicehash.address}.${accounts.nicehash.rigId} -k --nicehash`
 
+    if (download.windowsUrl !== undefined) {
+      definitions.push({
+        name: 'XMRig',
+        version: download.version,
+        algorithm: 'RandomX',
+        downloadUrl: download.windowsUrl,
+        exe: 'xmrig.exe',
+        args: `--no-cpu --cuda --opencl --donate-level=1 ${connection('usa')} ${connection('eu')}`,
+        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 3,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [negateGpuRequirement('*', 4096), hasGpu('*', 2048)],
+      })
+
+      definitions.push({
+        name: 'XMRig-CPU',
+        version: download.version,
+        algorithm: 'RandomX',
+        downloadUrl: download.windowsUrl,
+        exe: 'xmrig.exe',
+        args: `--donate-level=1 ${connection('usa')} ${connection('eu')}`,
+        runningCheck: '(?:accepted|[1-9][0-9]*\\.\\d* H\\/s)',
+        initialTimeout: 600000,
+        initialRetries: 3,
+        watchdogTimeout: 900000,
+        errors: [...STANDARD_ERRORS],
+        requirements: [hasCpu(3072)],
+      })
+    }
+
     if (download.windowsCudaUrl !== undefined) {
       definitions.push({
         name: 'XMRig',

--- a/packages/web-app/src/modules/salad-bowl/definitions/xmrig.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/xmrig.tsx
@@ -2,6 +2,12 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '6.12.1',
+    linuxUrl: baseUrl + '/xmrig-6.12.1/xmrig-6.12.1-linux.tar.gz',
+    macOSUrl: baseUrl + '/xmrig-6.12.1/xmrig-6.12.1-macos.tar.gz',
+    windowsUrl: baseUrl + '/xmrig-6.12.1/xmrig-6.12.1-windows.zip',
+  },
+  {
     version: '6.7.0',
     linuxUrl: baseUrl + '/xmrig-6.7.0/xmrig-6.7.0-linux.tar.gz',
     macOSUrl: baseUrl + '/xmrig-6.7.0/xmrig-6.7.0-macos.tar.gz',
@@ -14,12 +20,5 @@ export const downloads = [
     macOSUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-macos.tar.gz',
     windowsCudaUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-windows-cuda.zip',
     windowsOpenCLUrl: baseUrl + '/xmrig-6.6.2/xmrig-6.6.2-windows-opencl.zip',
-  },
-  {
-    version: '6.3.3',
-    linuxUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-linux.tar.gz',
-    macOSUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-macos.tar.gz',
-    windowsCudaUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-windows-cuda.zip',
-    windowsOpenCLUrl: baseUrl + '/xmrig-6.3.3/xmrig-6.3.3-windows-opencl.zip',
   },
 ]


### PR DESCRIPTION
- Update to GMiner 2.54
- Update to XMRig 6.12.1
- Fixes XMRig mining errors due to incorrect plugin download