### PR TITLE
Trimming whitespace in rewardValueItem.code

### DIFF
--- a/packages/web-app/src/modules/vault/VaultStore.ts
+++ b/packages/web-app/src/modules/vault/VaultStore.ts
@@ -32,7 +32,7 @@ export class VaultStore {
     name: r.name,
     price: r.price,
     timestamp: new Date(r.timestamp),
-    code: r.code ? r.code.trim() : r.code,
+    code: r.code?.trim(),
     status: r.status,
   })
 

--- a/packages/web-app/src/modules/vault/VaultStore.ts
+++ b/packages/web-app/src/modules/vault/VaultStore.ts
@@ -32,7 +32,7 @@ export class VaultStore {
     name: r.name,
     price: r.price,
     timestamp: new Date(r.timestamp),
-    code: r.code,
+    code: r.code ? r.code.trim() : r.code,
     status: r.status,
   })
 


### PR DESCRIPTION
"Some codes have leading or trailing white space, need to remove this white space when we load the data for the reward vault"