### PR TITLE
Add Antivirus Guide Link

### DIFF
--- a/packages/web-app/src/modules/machine-views/components/MinerTypePanel.tsx
+++ b/packages/web-app/src/modules/machine-views/components/MinerTypePanel.tsx
@@ -18,6 +18,9 @@ const styles = (theme: SaladTheme) => ({
   column: {
     flex: 1,
   },
+  antiVirusContainer: {
+    marginTop: 28,
+  },
 })
 
 interface Props extends WithStyles<typeof styles> {
@@ -65,6 +68,14 @@ class _MinerTypePanel extends Component<Props> {
               text={`Override ${gpuOnly ? 'GPU' : 'CPU'} Compatibility Detection`}
             />
             <InfoButton text={gpuOnly ? gpuOverrideInfo : cpuOverrideInfo} />
+          </div>
+          <div className={classes.antiVirusContainer}>
+            <P>
+              Having Antivirus issues?{' '}
+              <SmartLink to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus">
+                Open Antivirus guides
+              </SmartLink>
+            </P>
           </div>
         </div>
         <div className={classes.column}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37646831/128094017-b6b4b135-3d01-4fb2-830a-491e4a174861.png)

linking to our zendesk articles for now. we're going to need to come back and later and update the link with the modal once that has been built. 