### PR TITLE
Autorun fix

### DIFF
--- a/packages/web-app/src/PrivateRoute.tsx
+++ b/packages/web-app/src/PrivateRoute.tsx
@@ -3,8 +3,8 @@ import { Redirect, Route, RouteProps } from 'react-router-dom'
 
 interface Props extends RouteProps {
   component: any
-  isSignedIn: boolean
-  isAuthPending: boolean
+  isSignedIn?: boolean
+  isAuthPending?: boolean
 }
 
 /**

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -100,7 +100,9 @@ export class RootStore {
     this.refresh.start()
 
     autorun(() => {
-      if (this.auth.isAuthenticated) {
+      if (this.auth.isAuthenticated === undefined) {
+        return
+      } else if (this.auth.isAuthenticated) {
         this.onLogin()
       } else {
         this.onLogout()

--- a/packages/web-app/src/modules/auth/AuthStore.ts
+++ b/packages/web-app/src/modules/auth/AuthStore.ts
@@ -12,7 +12,7 @@ export enum FormSteps {
 export class AuthStore {
   /** A value indicating whether the user is authenticated. */
   @observable
-  public isAuthenticated: boolean = false
+  public isAuthenticated?: boolean = undefined
 
   /** A value indicating whether a value is being submitted. */
   @observable

--- a/packages/web-app/src/modules/salad-bowl/SaladBowlStore.ts
+++ b/packages/web-app/src/modules/salad-bowl/SaladBowlStore.ts
@@ -110,7 +110,7 @@ export class SaladBowlStore implements IPersistentStore {
   }
 
   @computed
-  get canRun(): boolean {
+  get canRun(): boolean | undefined {
     return (
       this.store.auth.isAuthenticated &&
       this.store.machine &&

--- a/packages/web-app/src/modules/salad-bowl/SaladBowlStore.ts
+++ b/packages/web-app/src/modules/salad-bowl/SaladBowlStore.ts
@@ -110,8 +110,9 @@ export class SaladBowlStore implements IPersistentStore {
   }
 
   @computed
-  get canRun(): boolean | undefined {
+  get canRun(): boolean {
     return (
+      this.store.auth.isAuthenticated !== undefined &&
       this.store.auth.isAuthenticated &&
       this.store.machine &&
       this.store.machine.currentMachine !== undefined &&


### PR DESCRIPTION
our `isAuthenticated` flag was previously set to an initial state of false even if this wasn't the actual state and this caused our `autoRun` function to be run twice (which would make `onLogout` run). Once on initial run, and once again after the `isAuthenticated` flag has been accurately set. This PR sets `isAuthenticated` to an initial state of undefined and exits the `autoRun` function if undefined which ensures we run `onLogin` or `onLogout` accurately. 