### PR TITLE
Show Autostart Page if Autostart Not Enabled

### DIFF
--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -175,6 +175,9 @@ export class RootStore {
       ])
 
       this.finishInitialLoading()
+      if (this.onboarding.shouldShowAutoStartPageAgain) {
+        this.onboarding.showAutoStartPageAgain()
+      }
       this.onboarding.showOnboardingIfNeeded()
     }.bind(this),
   )

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -177,10 +177,8 @@ export class RootStore {
       ])
 
       this.finishInitialLoading()
-      if (this.onboardingAutoStart.shouldShowAutoStartPageAgain) {
-        this.onboardingAutoStart.showAutoStartPageAgain()
-      }
       this.onboarding.showOnboardingIfNeeded()
+      this.onboarding.reshowOnboardingPagesIfNeeded()
     }.bind(this),
   )
 

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -11,7 +11,7 @@ import { EngagementStore } from './modules/engagement'
 import { HomeStore } from './modules/home/HomeStore'
 import { AutoStartStore, MachineSettingsUIStore, MachineStore, NativeStore } from './modules/machine'
 import { NotificationStore } from './modules/notifications'
-import { OnboardingAntivirusStore, OnboardingStore } from './modules/onboarding'
+import { OnboardingAntivirusStore, OnboardingAutoStartStore, OnboardingStore } from './modules/onboarding'
 import { ProfileStore } from './modules/profile'
 import { Profile } from './modules/profile/models'
 import { ReferralStore } from './modules/referral'
@@ -76,6 +76,7 @@ export class RootStore {
   public readonly bonuses: BonusStore
   public readonly seasons: SeasonsStore
   public readonly onboarding: OnboardingStore
+  public readonly onboardingAutoStart: OnboardingAutoStartStore
   public readonly onboardingAntivirus: OnboardingAntivirusStore
   public readonly saladFork: SaladFork
   public readonly startButtonUI: StartButtonUIStore
@@ -113,6 +114,7 @@ export class RootStore {
     this.bonuses = new BonusStore(this, axios)
     this.seasons = new SeasonsStore(axios)
     this.onboarding = new OnboardingStore(this)
+    this.onboardingAutoStart = new OnboardingAutoStartStore(this)
     this.onboardingAntivirus = new OnboardingAntivirusStore(this)
     this.startButtonUI = new StartButtonUIStore(this)
     this.machineSettingsUI = new MachineSettingsUIStore(this)
@@ -175,8 +177,8 @@ export class RootStore {
       ])
 
       this.finishInitialLoading()
-      if (this.onboarding.shouldShowAutoStartPageAgain) {
-        this.onboarding.showAutoStartPageAgain()
+      if (this.onboardingAutoStart.shouldShowAutoStartPageAgain) {
+        this.onboardingAutoStart.showAutoStartPageAgain()
       }
       this.onboarding.showOnboardingIfNeeded()
     }.bind(this),

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -28,7 +28,7 @@ const mapStoreToProps = (store: RootStore): any => {
     enableAutoStartPending: store.onboardingAutoStart.enableAutoStartPending,
     isDoNotShowAutoStartAgainChecked: store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked,
     onToggleDoNotShowAutoStartAgain: store.onboardingAutoStart.onToggleDoNotShowAutoStartAgain,
-    haveSeenAutoStartPage: store.onboardingAutoStart.haveSeenAutoStartPage,
+    hasSeenAutoStartPage: store.onboardingAutoStart.hasSeenAutoStartPage,
     isNative: store.native.isNative,
   }
 }

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -9,17 +9,21 @@ const mapStoreToProps = (store: RootStore): any => {
   const handleEnableAutoStart = () => {
     store.analytics.trackButtonClicked('enable_auto_start_button', 'Enable Auto-Start Button', 'enabled')
     store.onboardingAutoStart.enableAutoStart()
-    store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
+      store.routing.push('/')
+    } else {
+      store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     }
   }
 
   const handleOnSkipAutoStart = () => {
     store.analytics.trackButtonClicked('skip_auto_start_button', 'Skip Auto-Start Button', 'enabled')
-    store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
+      store.routing.push('/')
+    } else {
+      store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     }
   }
 

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -9,7 +9,7 @@ const mapStoreToProps = (store: RootStore): any => {
   const handleEnableAutoStart = () => {
     store.analytics.trackButtonClicked('enable_auto_start_button', 'Enable Auto-Start Button', 'enabled')
     store.onboardingAutoStart.enableAutoStart()
-    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
+    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainEnabled) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
       store.routing.push('/')
     } else {
@@ -19,7 +19,7 @@ const mapStoreToProps = (store: RootStore): any => {
 
   const handleOnSkipAutoStart = () => {
     store.analytics.trackButtonClicked('skip_auto_start_button', 'Skip Auto-Start Button', 'enabled')
-    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
+    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainEnabled) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
       store.routing.push('/')
     } else {
@@ -32,7 +32,7 @@ const mapStoreToProps = (store: RootStore): any => {
     onSkipAutoStart: handleOnSkipAutoStart,
     enableAutoStartErrorMessage: store.onboardingAutoStart.enableAutoStartErrorMessage,
     enableAutoStartPending: store.onboardingAutoStart.enableAutoStartPending,
-    isDoNotShowAutoStartAgainChecked: store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked,
+    isDoNotShowAutoStartAgainEnabled: store.onboardingAutoStart.isDoNotShowAutoStartAgainEnabled,
     onToggleDoNotShowAutoStartAgain: store.onboardingAutoStart.onToggleDoNotShowAutoStartAgain,
     hasSeenAutoStartPage: store.onboardingAutoStart.hasSeenAutoStartPage,
     isNative: store.native.isNative,

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -1,16 +1,24 @@
 import { connect } from '../../connect'
+import * as Storage from '../../Storage'
 import { RootStore } from '../../Store'
+import { DO_NOT_SHOW_AUTO_START_AGAIN } from '../onboarding/OnboardingStore'
 import { AutoStartConfigurationPage } from './pages/AutoStartConfigurationPage'
 
 const mapStoreToProps = (store: RootStore): any => {
   const handleEnableAutoStart = () => {
     store.analytics.trackButtonClicked('enable_auto_start_button', 'Enable Auto-Start Button', 'enabled')
     store.onboarding.enableAutoStart()
+    if (store.onboarding.isDoNotShowAutoStartAgainChecked) {
+      Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
+    }
   }
 
   const handleOnSkipAutoStart = () => {
     store.analytics.trackButtonClicked('skip_auto_start_button', 'Skip Auto-Start Button', 'enabled')
     store.onboarding.skipAutoStart()
+    if (store.onboarding.isDoNotShowAutoStartAgainChecked) {
+      Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
+    }
   }
 
   return {
@@ -18,6 +26,8 @@ const mapStoreToProps = (store: RootStore): any => {
     onSkipAutoStart: handleOnSkipAutoStart,
     enableAutoStartErrorMessage: store.onboarding.enableAutoStartErrorMessage,
     enableAutoStartPending: store.onboarding.enableAutoStartPending,
+    isDoNotShowAutoStartAgainChecked: store.onboarding.isDoNotShowAutoStartAgainChecked,
+    onToggleDoNotShowAutoStartAgain: store.onboarding.onToggleDoNotShowAutoStartAgain,
     haveSeenAutoStartPage: store.onboarding.haveSeenAutoStartPage,
     isNative: store.native.isNative,
   }

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -1,6 +1,7 @@
 import { connect } from '../../connect'
 import * as Storage from '../../Storage'
 import { RootStore } from '../../Store'
+import { ONBOARDING_PAGE_NAMES } from '../onboarding/models'
 import { DO_NOT_SHOW_AUTO_START_AGAIN } from '../onboarding/OnboardingAutoStartStore'
 import { AutoStartConfigurationPage } from './pages/AutoStartConfigurationPage'
 
@@ -8,6 +9,7 @@ const mapStoreToProps = (store: RootStore): any => {
   const handleEnableAutoStart = () => {
     store.analytics.trackButtonClicked('enable_auto_start_button', 'Enable Auto-Start Button', 'enabled')
     store.onboardingAutoStart.enableAutoStart()
+    store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
     }
@@ -15,7 +17,7 @@ const mapStoreToProps = (store: RootStore): any => {
 
   const handleOnSkipAutoStart = () => {
     store.analytics.trackButtonClicked('skip_auto_start_button', 'Skip Auto-Start Button', 'enabled')
-    store.onboardingAutoStart.skipAutoStart()
+    store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
     }

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -18,6 +18,7 @@ const mapStoreToProps = (store: RootStore): any => {
     onSkipAutoStart: handleOnSkipAutoStart,
     enableAutoStartErrorMessage: store.onboarding.enableAutoStartErrorMessage,
     enableAutoStartPending: store.onboarding.enableAutoStartPending,
+    haveSeenAutoStartPage: store.onboarding.haveSeenAutoStartPage,
     isNative: store.native.isNative,
   }
 }

--- a/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/AutoStartConfigurationContainer.tsx
@@ -1,22 +1,22 @@
 import { connect } from '../../connect'
 import * as Storage from '../../Storage'
 import { RootStore } from '../../Store'
-import { DO_NOT_SHOW_AUTO_START_AGAIN } from '../onboarding/OnboardingStore'
+import { DO_NOT_SHOW_AUTO_START_AGAIN } from '../onboarding/OnboardingAutoStartStore'
 import { AutoStartConfigurationPage } from './pages/AutoStartConfigurationPage'
 
 const mapStoreToProps = (store: RootStore): any => {
   const handleEnableAutoStart = () => {
     store.analytics.trackButtonClicked('enable_auto_start_button', 'Enable Auto-Start Button', 'enabled')
-    store.onboarding.enableAutoStart()
-    if (store.onboarding.isDoNotShowAutoStartAgainChecked) {
+    store.onboardingAutoStart.enableAutoStart()
+    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
     }
   }
 
   const handleOnSkipAutoStart = () => {
     store.analytics.trackButtonClicked('skip_auto_start_button', 'Skip Auto-Start Button', 'enabled')
-    store.onboarding.skipAutoStart()
-    if (store.onboarding.isDoNotShowAutoStartAgainChecked) {
+    store.onboardingAutoStart.skipAutoStart()
+    if (store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked) {
       Storage.setItem(DO_NOT_SHOW_AUTO_START_AGAIN, true)
     }
   }
@@ -24,11 +24,11 @@ const mapStoreToProps = (store: RootStore): any => {
   return {
     onEnableAutoStart: handleEnableAutoStart,
     onSkipAutoStart: handleOnSkipAutoStart,
-    enableAutoStartErrorMessage: store.onboarding.enableAutoStartErrorMessage,
-    enableAutoStartPending: store.onboarding.enableAutoStartPending,
-    isDoNotShowAutoStartAgainChecked: store.onboarding.isDoNotShowAutoStartAgainChecked,
-    onToggleDoNotShowAutoStartAgain: store.onboarding.onToggleDoNotShowAutoStartAgain,
-    haveSeenAutoStartPage: store.onboarding.haveSeenAutoStartPage,
+    enableAutoStartErrorMessage: store.onboardingAutoStart.enableAutoStartErrorMessage,
+    enableAutoStartPending: store.onboardingAutoStart.enableAutoStartPending,
+    isDoNotShowAutoStartAgainChecked: store.onboardingAutoStart.isDoNotShowAutoStartAgainChecked,
+    onToggleDoNotShowAutoStartAgain: store.onboardingAutoStart.onToggleDoNotShowAutoStartAgain,
+    haveSeenAutoStartPage: store.onboardingAutoStart.haveSeenAutoStartPage,
     isNative: store.native.isNative,
   }
 }

--- a/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
@@ -1,4 +1,4 @@
-import { Button, FieldContainer, Text } from '@saladtechnologies/garden-components'
+import { Button, Checkbox, FieldContainer, Text } from '@saladtechnologies/garden-components'
 import classnames from 'classnames'
 import withStyles, { WithStyles } from 'react-jss'
 import MediaQuery from 'react-responsive'
@@ -80,6 +80,7 @@ export interface AutoStartConfigurationPageProps extends WithStyles<typeof style
   enableAutoStartErrorMessage?: string
   onEnableAutoStart: () => void
   onSkipAutoStart: () => void
+  haveSeenAutoStartPage: boolean
 }
 
 const _AutoStartConfigurationPage = ({
@@ -87,6 +88,7 @@ const _AutoStartConfigurationPage = ({
   onSkipAutoStart,
   onEnableAutoStart,
   enableAutoStartPending,
+  haveSeenAutoStartPage,
   enableAutoStartErrorMessage,
 }: AutoStartConfigurationPageProps) => {
   return (
@@ -112,7 +114,7 @@ const _AutoStartConfigurationPage = ({
             <div className={classes.mb48}>
               <Text variant="baseS">Automatically chop when you are away from your PC</Text>
             </div>
-            <div className={classes.buttonsContainer}>
+            <div className={classnames(classes.buttonsContainer, classes.mb24)}>
               <span className={classes.leaveButton}>
                 <Button size="medium" label="Leave Auto-Start Disabled" onClick={onSkipAutoStart} variant="outlined" />
               </span>
@@ -127,6 +129,13 @@ const _AutoStartConfigurationPage = ({
                 />
               </span>
             </div>
+            {haveSeenAutoStartPage && (
+              <div>
+                <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={doNotShowAutoStartAgain}>
+                  <Text variant="baseS"> Do Not Show Again</Text>
+                </Checkbox>
+              </div>
+            )}
           </div>
           <MediaQuery minWidth={767}>
             <img className={classes.image} src={Carrot} alt="Salad Reward Items" />

--- a/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
@@ -81,13 +81,17 @@ export interface AutoStartConfigurationPageProps extends WithStyles<typeof style
   onEnableAutoStart: () => void
   onSkipAutoStart: () => void
   haveSeenAutoStartPage: boolean
+  isDoNotShowAutoStartAgainChecked: boolean
+  onToggleDoNotShowAutoStartAgain: (checked: boolean) => void
 }
 
 const _AutoStartConfigurationPage = ({
   classes,
   onSkipAutoStart,
   onEnableAutoStart,
+  onToggleDoNotShowAutoStartAgain,
   enableAutoStartPending,
+  isDoNotShowAutoStartAgainChecked,
   haveSeenAutoStartPage,
   enableAutoStartErrorMessage,
 }: AutoStartConfigurationPageProps) => {
@@ -131,7 +135,7 @@ const _AutoStartConfigurationPage = ({
             </div>
             {haveSeenAutoStartPage && (
               <div>
-                <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={doNotShowAutoStartAgain}>
+                <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={isDoNotShowAutoStartAgainChecked}>
                   <Text variant="baseS"> Do Not Show Again</Text>
                 </Checkbox>
               </div>

--- a/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
@@ -80,7 +80,7 @@ export interface AutoStartConfigurationPageProps extends WithStyles<typeof style
   enableAutoStartErrorMessage?: string
   onEnableAutoStart: () => void
   onSkipAutoStart: () => void
-  haveSeenAutoStartPage: boolean
+  hasSeenAutoStartPage: boolean
   isDoNotShowAutoStartAgainChecked: boolean
   onToggleDoNotShowAutoStartAgain: (checked: boolean) => void
 }
@@ -92,7 +92,7 @@ const _AutoStartConfigurationPage = ({
   onToggleDoNotShowAutoStartAgain,
   enableAutoStartPending,
   isDoNotShowAutoStartAgainChecked,
-  haveSeenAutoStartPage,
+  hasSeenAutoStartPage,
   enableAutoStartErrorMessage,
 }: AutoStartConfigurationPageProps) => {
   return (
@@ -133,7 +133,7 @@ const _AutoStartConfigurationPage = ({
                 />
               </span>
             </div>
-            {haveSeenAutoStartPage && (
+            {hasSeenAutoStartPage && (
               <div>
                 <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={isDoNotShowAutoStartAgainChecked}>
                   <Text variant="baseS"> Do Not Show Again</Text>

--- a/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AutoStartConfigurationPage.tsx
@@ -81,7 +81,7 @@ export interface AutoStartConfigurationPageProps extends WithStyles<typeof style
   onEnableAutoStart: () => void
   onSkipAutoStart: () => void
   hasSeenAutoStartPage: boolean
-  isDoNotShowAutoStartAgainChecked: boolean
+  isDoNotShowAutoStartAgainEnabled: boolean
   onToggleDoNotShowAutoStartAgain: (checked: boolean) => void
 }
 
@@ -91,7 +91,7 @@ const _AutoStartConfigurationPage = ({
   onEnableAutoStart,
   onToggleDoNotShowAutoStartAgain,
   enableAutoStartPending,
-  isDoNotShowAutoStartAgainChecked,
+  isDoNotShowAutoStartAgainEnabled,
   hasSeenAutoStartPage,
   enableAutoStartErrorMessage,
 }: AutoStartConfigurationPageProps) => {
@@ -135,7 +135,7 @@ const _AutoStartConfigurationPage = ({
             </div>
             {hasSeenAutoStartPage && (
               <div>
-                <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={isDoNotShowAutoStartAgainChecked}>
+                <Checkbox onChange={onToggleDoNotShowAutoStartAgain} checked={isDoNotShowAutoStartAgainEnabled}>
                   <Text variant="baseS"> Do Not Show Again</Text>
                 </Checkbox>
               </div>

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -16,11 +16,11 @@ export class OnboardingAutoStartStore {
   public isDoNotShowAutoStartAgainChecked: boolean = false
 
   @computed
-  public get haveSeenAutoStartPage(): boolean {
-    const haveSeenAutoStartPage =
+  public get hasSeenAutoStartPage(): boolean {
+    const hasSeenAutoStartPage =
       this.store.onboarding.onboardingPagesCompleted !== null &&
       this.store.onboarding.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-    return haveSeenAutoStartPage
+    return hasSeenAutoStartPage
   }
 
   @computed

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -37,11 +37,7 @@ export class OnboardingAutoStartStore {
 
   @computed
   public get userHasSelectedDoNotShowAutoStartAgain(): boolean {
-    if (Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN)) {
-      return true
-    } else {
-      return false
-    }
+    return typeof Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN) === 'string'
   }
 
   constructor(private readonly store: RootStore) {}

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -53,14 +53,8 @@ export class OnboardingAutoStartStore {
         'Something went wrong and we were unable to adjust your auto start settings. You can adjust these settings yourself in the Desktop App Settings, or contact support for assistance.'
     } finally {
       this.enableAutoStartPending = false
-      this.store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     }
   })
-
-  @action
-  public skipAutoStart = () => {
-    this.store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-  }
 
   @action
   public onToggleDoNotShowAutoStartAgain = (checked: boolean) => {

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -37,7 +37,7 @@ export class OnboardingAutoStartStore {
 
   @computed
   public get userHasSelectedDoNotShowAutoStartAgain(): boolean {
-    return typeof Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN) === 'string'
+    return Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN) === 'true'
   }
 
   constructor(private readonly store: RootStore) {}

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -1,0 +1,78 @@
+import { action, computed, flow, observable } from 'mobx'
+import * as Storage from '../../Storage'
+import { RootStore } from '../../Store'
+import { ONBOARDING_PAGE_NAMES } from './models'
+
+export const DO_NOT_SHOW_AUTO_START_AGAIN = 'DO_NOT_SHOW_AUTO_START_AGAIN'
+
+export class OnboardingAutoStartStore {
+  @observable
+  public enableAutoStartErrorMessage?: string = undefined
+
+  @observable
+  public enableAutoStartPending: boolean = false
+
+  @observable
+  public isDoNotShowAutoStartAgainChecked: boolean = false
+
+  @computed
+  public get haveSeenAutoStartPage(): boolean {
+    const haveSeenAutoStartPage =
+      this.store.onboarding.onboardingPagesCompleted !== null &&
+      this.store.onboarding.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
+    return haveSeenAutoStartPage
+  }
+
+  @computed
+  public get shouldShowAutoStartPageAgain(): boolean {
+    const shouldShowAutoStartPageAgain =
+      this.store.native.isNative &&
+      !this.store.autoStart.autoStart &&
+      this.store.onboarding.onboardingPagesCompleted !== null &&
+      this.store.onboarding.hasCompletedOnboarding &&
+      !this.userHasSelectedDoNotShowAutoStartAgain &&
+      this.store.onboarding.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
+    return shouldShowAutoStartPageAgain
+  }
+
+  @computed
+  public get userHasSelectedDoNotShowAutoStartAgain(): boolean {
+    if (Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN)) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  constructor(private readonly store: RootStore) {}
+
+  @action.bound
+  public enableAutoStart = flow(function* (this: OnboardingAutoStartStore) {
+    this.enableAutoStartErrorMessage = undefined
+    this.enableAutoStartPending = true
+    try {
+      yield this.store.autoStart.setAutoStart(true)
+    } catch {
+      this.enableAutoStartErrorMessage =
+        'Something went wrong and we were unable to adjust your auto start settings. You can adjust these settings yourself in the Desktop App Settings, or contact support for assistance.'
+    } finally {
+      this.enableAutoStartPending = false
+      this.store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
+    }
+  })
+
+  @action
+  public skipAutoStart = () => {
+    this.store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
+  }
+
+  @action
+  public onToggleDoNotShowAutoStartAgain = (checked: boolean) => {
+    this.isDoNotShowAutoStartAgainChecked = checked
+  }
+
+  @action
+  public showAutoStartPageAgain = () => {
+    this.store.routing.push('/onboarding/auto-start')
+  }
+}

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -13,7 +13,7 @@ export class OnboardingAutoStartStore {
   public enableAutoStartPending: boolean = false
 
   @observable
-  public isDoNotShowAutoStartAgainChecked: boolean = false
+  public isDoNotShowAutoStartAgainEnabled: boolean = false
 
   @computed
   public get hasSeenAutoStartPage(): boolean {
@@ -58,7 +58,7 @@ export class OnboardingAutoStartStore {
 
   @action
   public onToggleDoNotShowAutoStartAgain = (checked: boolean) => {
-    this.isDoNotShowAutoStartAgainChecked = checked
+    this.isDoNotShowAutoStartAgainEnabled = checked
   }
 
   @action

--- a/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAutoStartStore.tsx
@@ -29,7 +29,7 @@ export class OnboardingAutoStartStore {
       this.store.native.isNative &&
       !this.store.autoStart.autoStart &&
       this.store.onboarding.onboardingPagesCompleted !== null &&
-      this.store.onboarding.hasCompletedOnboarding &&
+      this.store.onboarding.hasCompletedAvailableOnboardingPages &&
       !this.userHasSelectedDoNotShowAutoStartAgain &&
       this.store.onboarding.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
     return shouldShowAutoStartPageAgain

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -6,7 +6,6 @@ import type { OnboardingPageItemType } from './models'
 import { OnboardingPageName, OnboardingPagesType, ONBOARDING_PAGE_NAMES } from './models'
 
 const ONBOARDING_STORAGE_KEY = 'ONBOARDING_PAGES_COMPLETED'
-export const DO_NOT_SHOW_AUTO_START_AGAIN = 'DO_NOT_SHOW_AUTO_START_AGAIN'
 
 export class OnboardingStore {
   private completedOnboardingPages: OnboardingPageName[] | [] = []
@@ -61,38 +60,6 @@ export class OnboardingStore {
   public disableSleepModeErrorMessage?: string = undefined
 
   @computed
-  public get haveSeenAutoStartPage(): boolean {
-    const haveSeenAutoStartPage =
-      this.onboardingPagesCompleted !== null &&
-      this.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-    return haveSeenAutoStartPage
-  }
-
-  @observable
-  public isDoNotShowAutoStartAgainChecked: boolean = false
-
-  @computed
-  public get shouldShowAutoStartPageAgain(): boolean {
-    const shouldShowAutoStartPageAgain =
-      this.store.native.isNative &&
-      !this.store.autoStart.autoStart &&
-      this.onboardingPagesCompleted !== null &&
-      this.hasCompletedOnboarding &&
-      !this.userHasSelectedDoNotShowAutoStartAgain &&
-      this.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-    return shouldShowAutoStartPageAgain
-  }
-
-  @computed
-  public get userHasSelectedDoNotShowAutoStartAgain(): boolean {
-    if (Storage.getItem(DO_NOT_SHOW_AUTO_START_AGAIN)) {
-      return true
-    } else {
-      return false
-    }
-  }
-
-  @computed
   public get hasCompletedOnboarding(): boolean {
     // if this is true, then we can push users to show autostartpageagain. but will maybe(?) have to have this above the showonboarding pages.
     const completedOnboarding =
@@ -102,15 +69,9 @@ export class OnboardingStore {
   }
 
   @computed
-  private get onboardingPagesCompleted(): string | null {
+  public get onboardingPagesCompleted(): string | null {
     return Storage.getItem(ONBOARDING_STORAGE_KEY)
   }
-
-  @observable
-  public enableAutoStartPending: boolean = false
-
-  @observable
-  public enableAutoStartErrorMessage?: string = undefined
 
   constructor(private readonly store: RootStore) {}
 
@@ -211,36 +172,6 @@ export class OnboardingStore {
   @action
   public skipSleepMode = () => {
     this.viewNextPage(ONBOARDING_PAGE_NAMES.SLEEP_MODE_CONFIGURATION)
-  }
-
-  @action.bound
-  public enableAutoStart = flow(function* (this: OnboardingStore) {
-    this.enableAutoStartErrorMessage = undefined
-    this.enableAutoStartPending = true
-    try {
-      yield this.store.autoStart.setAutoStart(true)
-    } catch {
-      this.enableAutoStartErrorMessage =
-        'Something went wrong and we were unable to adjust your auto start settings. You can adjust these settings yourself in the Desktop App Settings, or contact support for assistance.'
-    } finally {
-      this.enableAutoStartPending = false
-      this.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-    }
-  })
-
-  @action
-  public skipAutoStart = () => {
-    this.viewNextPage(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
-  }
-
-  @action
-  public onToggleDoNotShowAutoStartAgain = (checked: boolean) => {
-    this.isDoNotShowAutoStartAgainChecked = checked
-  }
-
-  @action
-  public showAutoStartPageAgain = () => {
-    this.store.routing.push('/onboarding/auto-start')
   }
 
   private findNextPageByOrder = (sortedOnboardingPages: OnboardingPagesType, nextPage: number) => {

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -22,7 +22,7 @@ export class OnboardingStore {
    * and whether or not it is only available in the native app.
    */
   @computed
-  private get onboardingPages(): OnboardingPageItemType[] {
+  private get availableOnboardingPages(): OnboardingPageItemType[] {
     const pages = [
       { NAME: ONBOARDING_PAGE_NAMES.WELCOME, PATH: '/onboarding/welcome', ORDER: 1, NATIVE: false },
       { NAME: ONBOARDING_PAGE_NAMES.REFERRAL, PATH: '/onboarding/referral', ORDER: 2, NATIVE: false },
@@ -208,7 +208,7 @@ export class OnboardingStore {
     let nextOnboardingPage = undefined
 
     if (typeof currentOnboardingPageOrder === 'number') {
-      const onboardingPagesCopy = [...this.onboardingPages]
+      const onboardingPagesCopy = [...this.availableOnboardingPages]
 
       const sortedOnboardingPages = onboardingPagesCopy.sort((a, b) => (a.ORDER > b.ORDER ? 1 : -1))
       const completedPagesCopy = [...this.completedOnboardingPages]
@@ -249,13 +249,13 @@ export class OnboardingStore {
   }
 
   private getOnboardingPage = (name: OnboardingPageName): OnboardingPageItemType | undefined => {
-    return this.onboardingPages.find((page) => page.NAME === name)
+    return this.availableOnboardingPages.find((page) => page.NAME === name)
   }
 
   private hasOnboardingPagesToComplete = (onboardingPagesCompletedInStorage: string | null): boolean => {
     const parsedStorageArray = onboardingPagesCompletedInStorage ? JSON.parse(onboardingPagesCompletedInStorage) : false
     if (parsedStorageArray) {
-      const onboardingPagesCopy = this.onboardingPages.map((page) => page.NAME)
+      const onboardingPagesCopy = this.availableOnboardingPages.map((page) => page.NAME)
       return !isEqual(sortBy(parsedStorageArray), sortBy(onboardingPagesCopy))
     } else {
       return true

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -60,6 +60,7 @@ export class OnboardingStore {
   public disableSleepModeErrorMessage?: string = undefined
 
   @computed
+  public get hasCompletedAvailableOnboardingPages(): boolean {
   public get hasCompletedOnboarding(): boolean {
     // if this is true, then we can push users to show autostartpageagain. but will maybe(?) have to have this above the showonboarding pages.
     const completedOnboarding =

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -61,11 +61,10 @@ export class OnboardingStore {
 
   @computed
   public get hasCompletedAvailableOnboardingPages(): boolean {
-  public get hasCompletedOnboarding(): boolean {
-    // if this is true, then we can push users to show autostartpageagain. but will maybe(?) have to have this above the showonboarding pages.
-    const completedOnboarding =
-      this.onboardingPagesCompleted !== null &&
-      this.availableOnboardingPages.length <= JSON.parse(this.onboardingPagesCompleted).length
+    const availableOnboardingPagesNameArray = this.availableOnboardingPages.map((item) => item.NAME)
+    const completedOnboarding = availableOnboardingPagesNameArray.some(
+      (e) => this.onboardingPagesCompleted !== null && JSON.parse(this.onboardingPagesCompleted).includes(e),
+    )
     return completedOnboarding
   }
 

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -63,7 +63,9 @@ export class OnboardingStore {
   public get hasCompletedAvailableOnboardingPages(): boolean {
     const availableOnboardingPagesNameArray = this.availableOnboardingPages.map((item) => item.NAME)
     const completedOnboarding = availableOnboardingPagesNameArray.some(
-      (e) => this.onboardingPagesCompleted !== null && JSON.parse(this.onboardingPagesCompleted).includes(e),
+      (onboardingPagesName) =>
+        this.onboardingPagesCompleted !== null &&
+        JSON.parse(this.onboardingPagesCompleted).includes(onboardingPagesName),
     )
     return completedOnboarding
   }

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -1,5 +1,5 @@
 import { isEqual, sortBy } from 'lodash'
-import { action, flow, observable } from 'mobx'
+import { action, computed, flow, observable } from 'mobx'
 import * as Storage from '../../Storage'
 import { RootStore } from '../../Store'
 import type { OnboardingPageItemType } from './models'
@@ -66,6 +66,11 @@ export class OnboardingStore {
   @observable
   public disableSleepModeErrorMessage?: string = undefined
 
+  @computed
+  private get onboardingPagesCompleted(): string | null {
+    return Storage.getItem(ONBOARDING_STORAGE_KEY)
+  }
+
   @observable
   public enableAutoStartPending: boolean = false
 
@@ -84,12 +89,12 @@ export class OnboardingStore {
      * If they have not but already have a referral code, we skip the
      * first two steps.
      */
-    if (onboardingPagesCompleted == null) {
+    if (this.onboardingPagesCompleted == null) {
       currentReferral
         ? this.updateCompletedOnboardingPages([ONBOARDING_PAGE_NAMES.WELCOME, ONBOARDING_PAGE_NAMES.REFERRAL])
         : this.updateCompletedOnboardingPages([])
     } else {
-      this.updateCompletedOnboardingPages(JSON.parse(onboardingPagesCompleted))
+      this.updateCompletedOnboardingPages(JSON.parse(this.onboardingPagesCompleted))
       if (currentReferral) {
         this.markOnboardingPageAsCompleted(ONBOARDING_PAGE_NAMES.WELCOME)
         this.markOnboardingPageAsCompleted(ONBOARDING_PAGE_NAMES.REFERRAL)
@@ -102,10 +107,10 @@ export class OnboardingStore {
      * it out in our onboardingPagesCompleted array with our updated Auto Start page name
      * so users do not see this page again.
      * */
-    if (onboardingPagesCompleted?.includes(ONBOARDING_PAGE_NAMES.AFK_CONFIGURATION)) {
+    if (this.onboardingPagesCompleted?.includes(ONBOARDING_PAGE_NAMES.AFK_CONFIGURATION)) {
       this.updateCompletedOnboardingPages(
         JSON.parse(
-          onboardingPagesCompleted.replace(
+          this.onboardingPagesCompleted.replace(
             ONBOARDING_PAGE_NAMES.AFK_CONFIGURATION,
             ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION,
           ),
@@ -113,7 +118,7 @@ export class OnboardingStore {
       )
     }
 
-    if (this.hasOnboardingPagesToComplete(onboardingPagesCompleted)) {
+    if (this.hasOnboardingPagesToComplete(this.onboardingPagesCompleted)) {
       this.routeToNextUncompletedPage()
     }
   }

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -60,6 +60,13 @@ export class OnboardingStore {
   public disableSleepModeErrorMessage?: string = undefined
 
   @computed
+  public get haveSeenAutoStartPage(): boolean {
+    const haveSeenAutoStartPage =
+      this.onboardingPagesCompleted !== null &&
+      this.onboardingPagesCompleted.includes(ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION)
+    return haveSeenAutoStartPage
+  }
+  @computed
   private get onboardingPagesCompleted(): string | null {
     return Storage.getItem(ONBOARDING_STORAGE_KEY)
   }

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -21,45 +21,38 @@ export class OnboardingStore {
    * Each item has a name, route, a completion order number,
    * and whether or not it is only available in the native app.
    */
-  private onboardingPages =
-    this.store.native.canWhitelistWindowsDefenderAndDisableSleepMode && this.store.native.isNative
-      ? [
-          { NAME: ONBOARDING_PAGE_NAMES.WELCOME, PATH: '/onboarding/welcome', ORDER: 1, NATIVE: false },
-          { NAME: ONBOARDING_PAGE_NAMES.REFERRAL, PATH: '/onboarding/referral', ORDER: 2, NATIVE: false },
-          {
-            NAME: ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION,
-            PATH: '/onboarding/auto-start',
-            ORDER: 3,
-            NATIVE: true,
-          },
-          {
-            NAME: ONBOARDING_PAGE_NAMES.SLEEP_MODE_CONFIGURATION,
-            PATH: '/onboarding/sleep-mode',
-            ORDER: 4,
-            NATIVE: true,
-          },
-          {
-            NAME: ONBOARDING_PAGE_NAMES.ANTIVIRUS_CONFIGURATION,
-            PATH: '/onboarding/antivirus-configuration',
-            ORDER: 5,
-            NATIVE: true,
-          },
-        ]
-      : this.store.native.isNative
-      ? [
-          { NAME: ONBOARDING_PAGE_NAMES.WELCOME, PATH: '/onboarding/welcome', ORDER: 1, NATIVE: false },
-          { NAME: ONBOARDING_PAGE_NAMES.REFERRAL, PATH: '/onboarding/referral', ORDER: 2, NATIVE: false },
-          {
-            NAME: ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION,
-            PATH: '/onboarding/auto-start',
-            ORDER: 3,
-            NATIVE: true,
-          },
-        ]
-      : [
-          { NAME: ONBOARDING_PAGE_NAMES.WELCOME, PATH: '/onboarding/welcome', ORDER: 1, NATIVE: false },
-          { NAME: ONBOARDING_PAGE_NAMES.REFERRAL, PATH: '/onboarding/referral', ORDER: 2, NATIVE: false },
-        ]
+  @computed
+  private get onboardingPages(): OnboardingPageItemType[] {
+    const pages = [
+      { NAME: ONBOARDING_PAGE_NAMES.WELCOME, PATH: '/onboarding/welcome', ORDER: 1, NATIVE: false },
+      { NAME: ONBOARDING_PAGE_NAMES.REFERRAL, PATH: '/onboarding/referral', ORDER: 2, NATIVE: false },
+    ]
+    if (this.store.native.isNative) {
+      pages.push({
+        NAME: ONBOARDING_PAGE_NAMES.AUTO_START_CONFIGURATION,
+        PATH: '/onboarding/auto-start',
+        ORDER: 3,
+        NATIVE: true,
+      })
+    }
+    if (this.store.native.canWhitelistWindowsDefenderAndDisableSleepMode) {
+      pages.push(
+        {
+          NAME: ONBOARDING_PAGE_NAMES.SLEEP_MODE_CONFIGURATION,
+          PATH: '/onboarding/sleep-mode',
+          ORDER: 4,
+          NATIVE: true,
+        },
+        {
+          NAME: ONBOARDING_PAGE_NAMES.ANTIVIRUS_CONFIGURATION,
+          PATH: '/onboarding/antivirus-configuration',
+          ORDER: 5,
+          NATIVE: true,
+        },
+      )
+    }
+    return pages
+  }
 
   public disableSleepModePending: boolean = false
 

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -130,6 +130,18 @@ export class OnboardingStore {
   }
 
   /**
+   * In the case of wanting to reshow a page on startup like the
+   * the Auto-Start page if certain conditions have not been met,
+   * this function will do that.
+   */
+  @action
+  public reshowOnboardingPagesIfNeeded = () => {
+    if (this.store.onboardingAutoStart.shouldShowAutoStartPageAgain) {
+      this.store.onboardingAutoStart.showAutoStartPageAgain()
+    }
+  }
+
+  /**
    * Updates onboarding store state and local storage with
    * an array of completed onboarding pages provided.
    * @param completedOnboardingPages An array of completed onboarding page names.

--- a/packages/web-app/src/modules/onboarding/index.tsx
+++ b/packages/web-app/src/modules/onboarding/index.tsx
@@ -1,2 +1,3 @@
 export * from './OnboardingAntivirusStore'
+export * from './OnboardingAutoStartStore'
 export * from './OnboardingStore'


### PR DESCRIPTION
If users have not enabled auto-start during their onboarding process, we will show the auto-start page again on startup but with a 'Do Not Show Again' checkbox. 

We only want to show this page again with the do not show again checkbox if users 
- have not seen the auto-start page before
- are on the desktop app
- don't have auto-start enabled
- haven't checked 'do not show me again'