### PR TITLE
Add experiment for the Help Scout support widget

### DIFF
--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -109,7 +109,7 @@ export class RootStore {
     this.vault = new VaultStore(axios, this.balance, this.rewards)
     this.version = new VersionStore(this, axios)
     this.engagement = new EngagementStore(this, axios)
-    this.zendesk = new Zendesk(axios, this.auth, this.native, this.analytics)
+    this.zendesk = new Zendesk(axios, featureManager, this.auth, this.native, this.analytics)
     this.storefront = new StorefrontStore(axios)
     this.bonuses = new BonusStore(this, axios)
     this.seasons = new SeasonsStore(axios)


### PR DESCRIPTION
Swaps out the Zendesk support widget for the Help Scout support widget if enabled by a feature flag.

This is a far from complete Help Scout integration, and the feature flag does not touch/affect the Zendesk guides loaded in our modals. This PR enables the bare minimum to help us test & demo the Help Scout platform features.