### PR TITLE
Adds AV tutorial videos to zendesk articles

### DIFF
--- a/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
@@ -13,6 +13,7 @@ const mapStoreToProps = (store: RootStore, ownProps: any): any => ({
   loadArticle: () => store.zendesk.loadArticle(parseInt(ownProps.match.params.id)),
   onCloseClicked: () => store.ui.hideModal(),
   onViewAVList: () => store.routing.push('/errors/anti-virus'),
+  antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
 })
 
 export const SpecificAntiVirusErrorContainer = withRouter(connect(mapStoreToProps, AntiVirusFirewallErrorPage))

--- a/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
+++ b/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
@@ -139,6 +139,7 @@ interface Props extends WithStyles<typeof styles> {
   onCloseClicked?: () => void
   onViewArticle?: (id: number) => void
   onViewAVList?: () => void
+  antiVirusGuideVideoId?: number
 }
 
 interface State {
@@ -195,6 +196,7 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
       onCloseClicked,
       onViewArticle,
       onViewAVList,
+      antiVirusGuideVideoId,
       classes,
     } = this.props
 
@@ -288,7 +290,21 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
                         </div>
                       </div>
                       {article ? (
-                        <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />
+                        <>
+                          {antiVirusGuideVideoId && (
+                            <>
+                              <iframe
+                                title={antivirusName}
+                                src={`//player.vimeo.com/video/${antiVirusGuideVideoId}`}
+                                width="640"
+                                height="360"
+                                frameBorder="0"
+                                allowFullScreen
+                              ></iframe>
+                            </>
+                          )}
+                          <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />{' '}
+                        </>
                       ) : articleList && onViewArticle ? (
                         <ul className={classes.list}>
                           {articleList.map((article) => (

--- a/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
@@ -14,6 +14,7 @@ const mapStoreToProps = (store: RootStore, ownProps: any): Omit<AntivirusGuidePr
     loadArticle: () => store.onboardingAntivirus.loadArticle(parseInt(ownProps.match.params.id)),
     onCloseClicked: () => store.onboarding.viewNextPage(ONBOARDING_PAGE_NAMES.ANTIVIRUS_CONFIGURATION),
     onViewAVList: () => store.routing.push('/onboarding/antivirus-guide'),
+    antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
   }
 }
 

--- a/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
@@ -127,6 +127,7 @@ export interface AntivirusGuideProps extends WithStyles<typeof styles> {
   loadArticle?: () => void
   onCloseClicked?: () => void
   onViewAVList?: () => void
+  antiVirusGuideVideoId?: number
 }
 
 interface State {
@@ -173,7 +174,7 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
   }
 
   render() {
-    const { antivirusName, article, loading, onCloseClicked, onViewAVList, classes } = this.props
+    const { antivirusName, article, loading, onCloseClicked, onViewAVList, antiVirusGuideVideoId, classes } = this.props
 
     const { webWidgetShowing } = this.state
 
@@ -216,7 +217,23 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
                       </>
                     </div>
                   </div>
-                  {article ? <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} /> : null}
+                  {article ? (
+                    <>
+                      {antiVirusGuideVideoId && (
+                        <>
+                          <iframe
+                            title={antivirusName}
+                            src={`//player.vimeo.com/video/${antiVirusGuideVideoId}`}
+                            width="640"
+                            height="360"
+                            frameBorder="0"
+                            allowFullScreen
+                          ></iframe>
+                        </>
+                      )}
+                      <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />{' '}
+                    </>
+                  ) : null}
                   <Button onClick={onCloseClicked}>Close</Button>
                 </>
               )}

--- a/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
@@ -154,6 +154,7 @@ export class OnboardingAntivirusStore {
   loadArticle = flow(
     function* (this: OnboardingAntivirusStore, articleID: number) {
       const antivirusSoftwareName = getZendeskAVData(articleID).name
+      this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
       if (antivirusSoftwareName === this.selectedAntiVirusGuide && this.helpCenterArticle !== undefined) {
         return
       }

--- a/packages/web-app/src/modules/zendesk/Zendesk.ts
+++ b/packages/web-app/src/modules/zendesk/Zendesk.ts
@@ -38,6 +38,9 @@ export class Zendesk {
   @observable
   public errorType: ErrorPageType = ErrorPageType.Unknown
 
+  @observable
+  public antiVirusGuideVideoId?: number
+
   private readonly useZendesk: boolean
 
   constructor(
@@ -410,7 +413,9 @@ export class Zendesk {
       if (avSoftwareName === this.selectedAntiVirusGuide && this.helpCenterArticle !== undefined) {
         return
       }
-
+      if (avSoftwareName !== undefined) {
+        this.antiVirusGuideVideoId = getZendeskAVData(avSoftwareName).videoId
+      }
       this.loadingArticle = true
       try {
         let res: Response = yield fetch(`https://salad.zendesk.com/api/v2/help_center/en-us/articles/${articleID}`, {

--- a/packages/web-app/src/modules/zendesk/utils.ts
+++ b/packages/web-app/src/modules/zendesk/utils.ts
@@ -36,10 +36,11 @@ type SystemProcessesData = si.ProcessesData
 interface ZendeskAVData {
   id?: number
   name?: AntiVirusSoftware
+  videoId?: number
 }
 
 export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number): ZendeskAVData => {
-  let zendeskAVData: ZendeskAVData = { id: undefined, name: undefined }
+  let zendeskAVData: ZendeskAVData = { id: undefined, name: undefined, videoId: undefined }
 
   switch (identifier) {
     case AntiVirusSoftware.Adaware:
@@ -56,6 +57,7 @@ export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number
     case 360033487211:
       zendeskAVData.id = 360033487211
       zendeskAVData.name = AntiVirusSoftware.Avast
+      zendeskAVData.videoId = 574387141
       break
     case AntiVirusSoftware.AVG:
     case 360041706612:
@@ -126,6 +128,7 @@ export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number
     case 360033488271:
       zendeskAVData.id = 360033488271
       zendeskAVData.name = AntiVirusSoftware.McAfeeSecurity
+      zendeskAVData.videoId = 575421455
       break
     case AntiVirusSoftware.Norton:
     case 360032211151:
@@ -186,6 +189,7 @@ export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number
     case 360033124692:
       zendeskAVData.id = 360033124692
       zendeskAVData.name = AntiVirusSoftware.WindowsDefender
+      zendeskAVData.videoId = 574423693
       break
     case AntiVirusSoftware.Zillya:
     case 360042225091:


### PR DESCRIPTION
The only AV guides that have videos are Windows Defender, Avast, and McAfee

![image](https://user-images.githubusercontent.com/37646831/136609774-2b12fe91-2b54-42c5-a094-a675fc1a2d91.png)
![image](https://user-images.githubusercontent.com/37646831/136609876-d52615ce-41e7-446c-af33-894b9c467c81.png)
![image](https://user-images.githubusercontent.com/37646831/136611760-9962f272-7c1e-4aa0-bb0c-6c722d472c81.png)
