### PR TITLE
Retrieve compatibility status from Salad Bowl

### DIFF
--- a/packages/web-app/src/modules/earn-views/pages/EarningsSummaryPage.tsx
+++ b/packages/web-app/src/modules/earn-views/pages/EarningsSummaryPage.tsx
@@ -240,7 +240,7 @@ const _EarningsSummaryPage = ({
             {isNative && (
               <div className={classes.detectedHardware}>
                 <div className={classnames(classes.sectionTitle, classes.lightGreenColor)}>
-                  <Text variant="base3XL">Active Workloads</Text>
+                  <Text variant="base3XL">Current Workloads</Text>
                 </div>
                 <div className={classes.activeWorkloadsContainer}>
                   <div className={classnames(classes.row, classes.titleRow)}>

--- a/packages/web-app/src/modules/machine/ActiveWorkloadsUIStore.tsx
+++ b/packages/web-app/src/modules/machine/ActiveWorkloadsUIStore.tsx
@@ -41,4 +41,33 @@ export class ActiveWorkloadsUIStore {
 
     return activeWorkloads
   }
+
+  @computed
+  get hasCompatibleWorkloads(): boolean {
+    let compatible: boolean = false
+
+    const workloads = this.store.saladBowl.workloadState
+    if (workloads !== undefined) {
+      const filteredWorkloads = workloads.filter((workload) => {
+        if (workload.id === 'gpuz' || workload.id === 'systeminformation') {
+          return false
+        } else {
+          return true
+        }
+      })
+
+      if (this.store.saladBowl.cpuMiningOverridden || this.store.saladBowl.gpuMiningOverridden) {
+        compatible = true
+      } else if (
+        filteredWorkloads.length > 0 &&
+        (this.store.saladBowl.cpuMiningEnabled || this.store.saladBowl.gpuMiningEnabled)
+      ) {
+        compatible = true
+      }
+    } else {
+      compatible = false
+    }
+
+    return compatible
+  }
 }

--- a/packages/web-app/src/modules/machine/MachineStore.ts
+++ b/packages/web-app/src/modules/machine/MachineStore.ts
@@ -45,6 +45,10 @@ export class MachineStore {
         return
       }
 
+      if (store.saladBowl.saladBowlConnected === undefined) {
+        return
+      }
+
       await this.registerMachine()
     })
   }

--- a/packages/web-app/src/modules/salad-bowl/SaladForkAndBowlStore.tsx
+++ b/packages/web-app/src/modules/salad-bowl/SaladForkAndBowlStore.tsx
@@ -61,7 +61,7 @@ export class SaladForkAndBowlStore implements SaladBowlStoreInterface {
   public plugin = new PluginInfo()
 
   @observable
-  public saladBowlConnected?: boolean = false
+  public saladBowlConnected?: boolean
 
   @observable
   public workloadState?: SBWorkloadState.AsObject[]
@@ -84,9 +84,13 @@ export class SaladForkAndBowlStore implements SaladBowlStoreInterface {
 
   @computed
   get canRun() {
-    // Should also have a check if we are connected to Salad Bowl 2.0, have available workloads, have a workload enabled
     return (
-      this.store.auth.isAuthenticated !== undefined && this.store.auth.isAuthenticated && this.store.native.isNative
+      this.store.auth.isAuthenticated !== undefined &&
+      this.store.auth.isAuthenticated &&
+      this.store.native.isNative &&
+      this.saladBowlConnected !== undefined &&
+      this.saladBowlConnected &&
+      this.store.activeWorkloadsUIStore.hasCompatibleWorkloads
     )
   }
 
@@ -283,9 +287,6 @@ export class SaladForkAndBowlStore implements SaladBowlStoreInterface {
 
         // start streaming workload data
         this.streamWorkloadData()
-
-        // start streaming workload state - TODO: This should be moved to the main store after a succesful login
-        this.streamWorkloadState()
 
         // TODO: This anaytics metric is probably not going to work anymore?
         // const gpusNames = this.store.machine.gpus.filter((x) => x && x.model).map((x) => x.model)


### PR DESCRIPTION
- Updates the `canRun` flag in the new Salad Bowl store to detect if a user can chop based on the registered workloads provided via Salad Bowl. 