### PR TITLE
Clear Startbutton Tooltip on Start

### DIFF
--- a/packages/web-app/src/modules/start-button/StartButtonUIStore.tsx
+++ b/packages/web-app/src/modules/start-button/StartButtonUIStore.tsx
@@ -82,7 +82,10 @@ export class StartButtonUIStore {
       label: isAuthenticated ? (saladBowlConnected ? label : saladBowlPendingLabel) : 'Login',
       onClick:
         isNative && saladBowlConnected
-          ? () => this.store.saladBowl.toggleRunning(StartActionType.StartButton)
+          ? () => {
+              this.store.saladBowl.toggleRunning(StartActionType.StartButton)
+              this.startButtonToolTip && setTimeout(() => this.setStartButtonToolTip(undefined), 1000)
+            }
           : isNative && !saladBowlConnected
           ? notConnected
           : isAuthenticated


### PR DESCRIPTION
clears out the tooltip after a second when users click on start if tooltip exists