### PR TITLE
Add experiment for the Intercom support widget

### DIFF
--- a/packages/web-app/src/modules/zendesk/Zendesk.ts
+++ b/packages/web-app/src/modules/zendesk/Zendesk.ts
@@ -10,6 +10,8 @@ import type { NativeStore } from '../machine'
 import type { AntiVirusSoftware, ZendeskArticle, ZendeskArticleList, ZendeskArticleResource } from './models'
 import { getAntiVirusSoftware, getZendeskAVData } from './utils'
 
+const INTERCOM_APP_ID = 'tkraexri'
+
 export class Zendesk {
   private static injected: boolean = false
 
@@ -50,7 +52,7 @@ export class Zendesk {
     private readonly native: NativeStore,
     private readonly analytics: AnalyticsStore,
   ) {
-    this.useZendesk = !featureManager.isEnabled('app_helpscout')
+    this.useZendesk = !featureManager.isEnabled('app_intercom')
     this.inject()
   }
 
@@ -208,18 +210,16 @@ export class Zendesk {
         zendeskSnippetScript.src = 'https://static.zdassets.com/ekr/snippet.js?key=36be7184-2a3f-4bec-9bb2-758e7c9036d0'
         document.body.appendChild(zendeskSnippetScript)
       } else {
-        // Append Help Scout script to body.
+        // Append Intercom script to body.
         /* eslint-disable */
         /* prettier-ignore */
         /* @ts-ignore */
-        !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-        /* prettier-ignore */
-        /* @ts-ignore */
-        window.Beacon('init', '29fdaae4-715f-48dc-b93e-5552ef031abc');
-        /* prettier-ignore */
-        /* @ts-ignore */
-        ;(function(){var u='https://unpkg.com/@helpscout/beacon-devtools/dist/beacon-devtools.umd.js';var s=document.createElement('script');s.type='text/javascript';s.charset='utf-8';s.src=u;document.body.appendChild(s)})();
-        /* eslint-enable */
+        ;(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/'+INTERCOM_APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+        if (window.Intercom) {
+          window.Intercom('boot', {
+            app_id: INTERCOM_APP_ID,
+          })
+        }
       }
 
       Zendesk.injected = true
@@ -287,8 +287,12 @@ export class Zendesk {
         this.initializeRetryTimeout = undefined
       }
     } else {
-      if (window.Beacon) {
-        window.Beacon('identify', { name: username, email })
+      if (window.Intercom) {
+        window.Intercom('boot', {
+          app_id: INTERCOM_APP_ID,
+          email,
+          name: username,
+        })
       }
     }
   }
@@ -337,9 +341,11 @@ export class Zendesk {
         console.error(e)
       }
     } else {
-      if (window.Beacon) {
-        window.Beacon('reset')
-        window.Beacon('logout', { endActiveChat: true })
+      if (window.Intercom) {
+        window.Intercom('shutdown')
+        window.Intercom('boot', {
+          app_id: INTERCOM_APP_ID,
+        })
       }
     }
   }

--- a/packages/web-app/src/modules/zendesk/models/ZendeskWebWidget.ts
+++ b/packages/web-app/src/modules/zendesk/models/ZendeskWebWidget.ts
@@ -1,20 +1,14 @@
 import type { Ref } from 'react'
 
-declare function Beacon(method: 'init', beaconId: string): void
-declare function Beacon(method: 'destroy'): void
-declare function Beacon(method: 'open'): void
-declare function Beacon(method: 'close'): void
-declare function Beacon(method: 'toggle'): void
-declare function Beacon(method: 'search', query: string): void
-declare function Beacon(method: 'suggest'): void
-declare function Beacon(method: 'article', articleId: string, options?: { type: 'modal' | 'sidebar' }): void
-declare function Beacon(method: 'navigate', route: string): void
-declare function Beacon(method: 'identify', userObject: { name: string; email: string; signature?: string }): void
-declare function Beacon(method: 'prefill', formObject: {}): void
-declare function Beacon(method: 'reset'): void
-declare function Beacon(method: 'logout', options?: { endActiveChat: true }): void
-declare function Beacon(method: 'config', formObject: {}): void
-declare function Beacon(method: 'info'): void
+export interface IntercomSettings {
+  app_id: string
+  email?: string
+  user_id?: string
+  name?: string
+}
+
+declare function Intercom(method: 'boot', settings: IntercomSettings): void
+declare function Intercom(method: 'shutdown'): void
 
 export interface ZendeskWidget {
   (type: 'webWidget:on' | 'webWidget' | 'webWidget:get', command: string, payload?: any): void
@@ -167,7 +161,7 @@ export interface ZendeskSettings {
 
 declare global {
   interface Window {
-    Beacon?: typeof Beacon
+    Intercom?: typeof Intercom
     zESettings?: ZendeskSettings
     zE?: ZendeskWidget
     // https://support.trustpilot.com/hc/en-us/articles/115011421468--Add-a-TrustBox-to-a-single-page-application


### PR DESCRIPTION
Swaps out the Zendesk support widget for the Intercom support widget if enabled by a feature flag.

This is a far from complete Intercom integration, and the feature flag does not touch/affect the Zendesk guides loaded in our modals. This PR enables the bare minimum to help us test & demo the Intercom platform features.