### PR TITLE
Adds override option for searchKey and searchEngine

### DIFF
--- a/packages/web-app/src/config.ts
+++ b/packages/web-app/src/config.ts
@@ -41,8 +41,6 @@ export class Config {
   public readonly rewardRefreshRate: number = numberOrDefault('REACT_APP_REWARD_REFRESH_RATE', convertMinutes(5))
   public readonly sentryDSN?: string = optionalString('REACT_APP_SENTRY_DSN')
   public readonly searchUrl: string = requiredString('REACT_APP_SEARCH_URL')
-  public readonly searchKey: string = requiredString('REACT_APP_SEARCH_KEY')
-  public readonly searchEngine: string = requiredString('REACT_APP_SEARCH_ENGINE')
   public readonly strapiUploadUrl: string = requiredString('REACT_APP_STRAPI_UPLOAD_URL')
 
   public get apiBaseUrl(): string {
@@ -51,6 +49,24 @@ export class Config {
       return override
     } else {
       return requiredString('REACT_APP_API_URL')
+    }
+  }
+
+  public get searchKey(): string {
+    const override = Storage.getItem('OVERRIDE_SEARCH_KEY')
+    if (override != null) {
+      return override
+    } else {
+      return requiredString('REACT_APP_SEARCH_KEY')
+    }
+  }
+
+  public get searchEngine(): string {
+    const override = Storage.getItem('OVERRIDE_SEARCH_ENGINE')
+    if (override != null) {
+      return override
+    } else {
+      return requiredString('REACT_APP_SEARCH_ENGINE')
     }
   }
 }


### PR DESCRIPTION
when we would search for things before, we would always hit the prod server. we now have an option to hit other backends when searching. 

before:
![image](https://user-images.githubusercontent.com/37646831/140397686-188deb0c-28a4-454f-bc4e-6d4a689492af.png)


after:
![image](https://user-images.githubusercontent.com/37646831/140397038-6d708e8f-0caa-42c1-8f01-6f5a2ceb405e.png)
