### PR TITLE
If user has reached last xp level default to 100% complete

### DIFF
--- a/packages/web-app/src/modules/xp/ExperienceStore.ts
+++ b/packages/web-app/src/modules/xp/ExperienceStore.ts
@@ -21,6 +21,7 @@ export class ExperienceStore {
   }
 
   @computed get currentPercentComplete(): number {
+    if (this.currentXp > 131400) return 1;
     const level = this.currentLevel
     let totalRange = level.maxXp - level.minXp
     let delta = this.currentXp - level.minXp


### PR DESCRIPTION
When the user reaches the last Xp milestone, the display on the right side of the screen should remain at the last milestone instead of getting more and more scrambled again.
This should default the completion to 100% if the user has more Xp than the milestone, but honestly i have no clue if it actually works