### PR TITLE
Fix Pantry Animation Bug

### DIFF
--- a/packages/web-app/src/modules/xp/ExperienceStore.ts
+++ b/packages/web-app/src/modules/xp/ExperienceStore.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios'
 import { action, computed, flow, observable } from 'mobx'
-import { defaultLevels } from './models/defaultLevels'
+import { defaultLevels, totalXpRequiredForAllVegies } from './models/defaultLevels'
 import { Level } from './models/Level'
 
 export class ExperienceStore {
@@ -21,6 +21,10 @@ export class ExperienceStore {
   }
 
   @computed get currentPercentComplete(): number {
+    if (this.currentXp > totalXpRequiredForAllVegies) {
+      return 1
+    }
+
     const level = this.currentLevel
     let totalRange = level.maxXp - level.minXp
     let delta = this.currentXp - level.minXp

--- a/packages/web-app/src/modules/xp/ExperienceStore.ts
+++ b/packages/web-app/src/modules/xp/ExperienceStore.ts
@@ -21,7 +21,7 @@ export class ExperienceStore {
   }
 
   @computed get currentPercentComplete(): number {
-    if (this.currentXp > totalXpRequiredForAllVegies) {
+    if (this.currentXp >= totalXpRequiredForAllVegies) {
       return 1
     }
 
@@ -50,8 +50,8 @@ export class ExperienceStore {
       let res = yield this.axios.get('/api/v1/profile/xp')
 
       let newXp = res.data.lifetimeXp
-
-      this.updateXp(newXp)
+      console.log(newXp)
+      this.updateXp(100000000000)
     } catch {}
   })
 }

--- a/packages/web-app/src/modules/xp/ExperienceStore.ts
+++ b/packages/web-app/src/modules/xp/ExperienceStore.ts
@@ -50,8 +50,8 @@ export class ExperienceStore {
       let res = yield this.axios.get('/api/v1/profile/xp')
 
       let newXp = res.data.lifetimeXp
-      console.log(newXp)
-      this.updateXp(100000000000)
+
+      this.updateXp(newXp)
     } catch {}
   })
 }

--- a/packages/web-app/src/modules/xp/models/defaultLevels.ts
+++ b/packages/web-app/src/modules/xp/models/defaultLevels.ts
@@ -43,6 +43,7 @@ const veggies = [
  * Should be modified in conjunction with `linearFactor`
  */
 const curveFactor = 3.529964328
+export const totalXpRequiredForAllVegies = 131400
 
 /**
  * Linear factor. Ensures that the polynomial curve is not too flat initially.


### PR DESCRIPTION
If a user has reached the XP level required to get all the vegies(131400) in the pantry, the animation will stop moving. 