### PR TITLE
Reset account onboarding pages completed on logout

### DIFF
--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -199,6 +199,7 @@ export class RootStore {
 
     this.referral.currentReferral = undefined
     this.referral.referralCode = ''
+    this.onboarding.resetAccountOnboardingPagesCompleted()
 
     this.analytics.trackLogout()
     this.native.logout()

--- a/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingStore.tsx
@@ -168,6 +168,28 @@ export class OnboardingStore {
     }
   }
 
+  /**
+   * Removes all account related onboarding pages from local storage.
+   */
+  @action
+  public resetAccountOnboardingPagesCompleted = () => {
+    if (this.onboardingPagesCompleted) {
+      const completedOnboardingPages = JSON.parse(this.onboardingPagesCompleted)
+
+      const welcomeIndex = completedOnboardingPages.indexOf(ONBOARDING_PAGE_NAMES.WELCOME)
+      if (welcomeIndex > -1) {
+        completedOnboardingPages.splice(welcomeIndex, 1)
+      }
+
+      const referralIndex = completedOnboardingPages.indexOf(ONBOARDING_PAGE_NAMES.REFERRAL)
+      if (referralIndex > -1) {
+        completedOnboardingPages.splice(referralIndex, 1)
+      }
+
+      this.updateCompletedOnboardingPages(completedOnboardingPages)
+    }
+  }
+
   @action.bound
   public disableSleepMode = flow(function* (this: OnboardingStore) {
     this.disableSleepModeErrorMessage = undefined


### PR DESCRIPTION
Since all onboarding pages are tracked via local storage, if a different user logs into the Salad App on a friends computer for the first time, they will never see a welcome or referral code onboarding page. Resetting these account onboarding pages on logout will allow for a different user to setup their account in this scenario. 