### PR TITLE
Use 60 second intervals for feature toggle updates & reporting

### DIFF
--- a/packages/web-app/src/FeatureManager.tsx
+++ b/packages/web-app/src/FeatureManager.tsx
@@ -21,6 +21,8 @@ export class UnleashFeatureManager implements FeatureManager {
         url: process.env.REACT_APP_UNLEASH_URL,
         clientKey: process.env.REACT_APP_UNLEASH_API_KEY,
         appName: 'web-app',
+        refreshInterval: 60,
+        metricsInterval: 60,
       })
 
       // TODO: refactor to add this at top app-level initialization


### PR DESCRIPTION
This slows things down a bit. Our users won't see updates all that quickly, so there's no need to use up the extra bandwidth.