### PR TITLE
Fix for linux bug on some machines preventing drivers from being recognized

### DIFF
--- a/packages/desktop-app/src/main.ts
+++ b/packages/desktop-app/src/main.ts
@@ -378,7 +378,7 @@ const createMainWindow = () => {
     }
 
     machineInfo.then((info) => {
-      bridge.send('set-machine-info', info)
+      bridge.send('set-machine-info', JSON.parse(JSON.stringify(info)))
     })
   })
 


### PR DESCRIPTION
on both my rx580 desktop and my 1660 ti laptop I got the same error so I thought I'd pr my fix. (both running archlinux and building it manually)

this is a fix for
```js
Error sending from webFrameMain: Error: Failed to serialize arguments
    at Object.n.send (node:electron/js2c/browser_init:165:417)
    at Object.send (node:electron/js2c/browser_init:161:2492)
    at SaladBridge.send (/opt/Salad/resources/app.asar/webpack:src/SaladBridge.ts:21:29)
    at /opt/Salad/resources/app.asar/webpack:src/main.ts:381:14
```

based on that there was a part of the object returned from the hardware polling lib salad uses that prevents serialization for sending to the "web" component, in order to fix this I use json to serialize and then deserialize it,
json's seriailizer will skip un-serializable parts (usually making them just `{}`) and so this basically sanitizes the object for electron's more strict parser.