### PR TITLE
[Bug] broken Auto Start link

### DIFF
--- a/packages/web-app/src/modules/earn-views/MiningInformationContainer.ts
+++ b/packages/web-app/src/modules/earn-views/MiningInformationContainer.ts
@@ -1,6 +1,11 @@
 import { connect } from '../../connect'
+import { RootStore } from '../../Store'
 import { MiningInformation } from './components/MiningInformation'
 
-const mapStoreToProps = (): any => ({})
+const mapStoreToProps = (store: RootStore): any => {
+  return {
+    isNative: store.native.isNative,
+  }
+}
 
 export const MiningInformationContainer = connect(mapStoreToProps, MiningInformation)

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.stories.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.stories.tsx
@@ -9,4 +9,4 @@ export default {
   ],
 } as Meta
 
-export const IncompatibleGPUAndOS = () => <MiningInformation />
+export const IncompatibleGPUAndOS = () => <MiningInformation isNative={false} />

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -79,13 +79,9 @@ class _MiningInformation extends Component<Props> {
 
             <P>
               Don't forget to enable{' '}
-              {isNative ? (
-                <b>
-                  <SmartLink to="/account/desktop-settings">Auto Start</SmartLink>
-                </b>
-              ) : (
-                <b> Auto Start </b>
-              )}
+              <b>
+                {isNative ? <SmartLink to="/account/desktop-settings">Auto Start</SmartLink> : <span>Auto Start</span>}
+              </b>
               , this will allow Salad to automatically start when you step away from your machine.
             </P>
             <Divider />

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -38,11 +38,13 @@ const styles = (theme: SaladTheme) => ({
   },
 })
 
-interface Props extends WithStyles<typeof styles> {}
+interface Props extends WithStyles<typeof styles> {
+  isNative: boolean
+}
 
 class _MiningInformation extends Component<Props> {
   render() {
-    const { classes } = this.props
+    const { classes, isNative } = this.props
 
     return (
       <div className={classes.container}>
@@ -77,9 +79,13 @@ class _MiningInformation extends Component<Props> {
 
             <P>
               Don't forget to enable{' '}
-              <b>
-                <SmartLink to="/settings/desktop-settings">Auto Start</SmartLink>
-              </b>
+              {isNative ? (
+                <b>
+                  <SmartLink to="/account/desktop-settings">Auto Start</SmartLink>
+                </b>
+              ) : (
+                <b> Auto Start </b>
+              )}
               , this will allow Salad to automatically start when you step away from your machine.
             </P>
             <Divider />


### PR DESCRIPTION
we had a link to the desktop settings page that would always show even in the webapp. this page wasn't accessible though unless you were in the desktop app so i added a check to see if we're in the native app. the path has also changed so i updated it. 
![image](https://user-images.githubusercontent.com/37646831/150864900-0e2a82b4-2419-49c1-806b-ebc1613161ce.png)