### PR TITLE
[Bug] Open Earn FAQ links in same window

### DIFF
--- a/packages/web-app/src/components/SmartLink.tsx
+++ b/packages/web-app/src/components/SmartLink.tsx
@@ -23,7 +23,6 @@ interface Props extends WithStyles<typeof styles> {
   children?: ReactNode
   className?: string
   trackingInfo?: LinkTrackingInfo
-  openInSameWindow?: boolean
 }
 
 const handleClickTracking = (to?: string, trackingInfo?: any) => {
@@ -33,7 +32,7 @@ const handleClickTracking = (to?: string, trackingInfo?: any) => {
   }
 }
 
-const _SmartLink = ({ to, children, classes, className, trackingInfo, openInSameWindow }: Props) => {
+const _SmartLink = ({ to, children, classes, className, trackingInfo }: Props) => {
   const isTextChild = typeof children === 'string'
   const finalClassName = classnames(classes.link, className, { [classes.hideUnderline]: !isTextChild })
 
@@ -42,7 +41,7 @@ const _SmartLink = ({ to, children, classes, className, trackingInfo, openInSame
       <a
         className={finalClassName}
         href={to}
-        target={openInSameWindow ? undefined : '_blank'}
+        target={'_blank'}
         rel="noopener noreferrer"
         onClick={trackingInfo ? () => handleClickTracking(to, trackingInfo) : undefined}
       >

--- a/packages/web-app/src/components/SmartLink.tsx
+++ b/packages/web-app/src/components/SmartLink.tsx
@@ -23,6 +23,7 @@ interface Props extends WithStyles<typeof styles> {
   children?: ReactNode
   className?: string
   trackingInfo?: LinkTrackingInfo
+  openInSameWindow?: boolean
 }
 
 const handleClickTracking = (to?: string, trackingInfo?: any) => {
@@ -32,7 +33,7 @@ const handleClickTracking = (to?: string, trackingInfo?: any) => {
   }
 }
 
-const _SmartLink = ({ to, children, classes, className, trackingInfo }: Props) => {
+const _SmartLink = ({ to, children, classes, className, trackingInfo, openInSameWindow }: Props) => {
   const isTextChild = typeof children === 'string'
   const finalClassName = classnames(classes.link, className, { [classes.hideUnderline]: !isTextChild })
 
@@ -41,7 +42,7 @@ const _SmartLink = ({ to, children, classes, className, trackingInfo }: Props) =
       <a
         className={finalClassName}
         href={to}
-        target={'_blank'}
+        target={openInSameWindow ? undefined : '_blank'}
         rel="noopener noreferrer"
         onClick={trackingInfo ? () => handleClickTracking(to, trackingInfo) : undefined}
       >

--- a/packages/web-app/src/components/SmartLink.tsx
+++ b/packages/web-app/src/components/SmartLink.tsx
@@ -23,7 +23,6 @@ interface Props extends WithStyles<typeof styles> {
   children?: ReactNode
   className?: string
   trackingInfo?: LinkTrackingInfo
-  openInSameWindow?: boolean
 }
 
 const handleClickTracking = (to?: string, trackingInfo?: any) => {
@@ -33,16 +32,17 @@ const handleClickTracking = (to?: string, trackingInfo?: any) => {
   }
 }
 
-const _SmartLink = ({ to, children, classes, className, trackingInfo, openInSameWindow }: Props) => {
+const _SmartLink = ({ to, children, classes, className, trackingInfo }: Props) => {
   const isTextChild = typeof children === 'string'
   const finalClassName = classnames(classes.link, className, { [classes.hideUnderline]: !isTextChild })
-
+  const store: RootStore = getStore()
+  const isNative = store.native.isNative
   if (to === undefined || to.startsWith('http')) {
     return (
       <a
         className={finalClassName}
         href={to}
-        target={openInSameWindow ? undefined : '_blank'}
+        target={isNative ? '_blank' : undefined}
         rel="noopener noreferrer"
         onClick={trackingInfo ? () => handleClickTracking(to, trackingInfo) : undefined}
       >

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -110,22 +110,31 @@ class _MiningInformation extends Component<Props> {
                 <SectionHeader>More Information</SectionHeader>
                 <br />
                 <P>
-                  <SmartLink to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus">
+                  <SmartLink
+                    openInSameWindow={true}
+                    to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus"
+                  >
                     Having Anti-Virus Issues?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/gamers-guide-blockchain-crypto">
+                  <SmartLink openInSameWindow={true} to="https://salad.com/blog/gamers-guide-blockchain-crypto">
                     Gamers Guide to Blockchain
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/making-money-with-salad-whats-the-catch">
+                  <SmartLink
+                    openInSameWindow={true}
+                    to="https://salad.com/blog/making-money-with-salad-whats-the-catch"
+                  >
                     What's the Catch?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu">
+                  <SmartLink
+                    openInSameWindow={true}
+                    to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu"
+                  >
                     Does mining hurt my machine?
                   </SmartLink>
                 </P>

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -110,22 +110,28 @@ class _MiningInformation extends Component<Props> {
                 <SectionHeader>More Information</SectionHeader>
                 <br />
                 <P>
-                  <SmartLink to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus">
+                  <SmartLink
+                    openInSameWindow={true}
+                    to="http://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus"
+                  >
                     Having Anti-Virus Issues?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/gamers-guide-blockchain-crypto">
+                  <SmartLink openInSameWindow={true} to="http://salad.com/blog/gamers-guide-blockchain-crypto">
                     Gamers Guide to Blockchain
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/making-money-with-salad-whats-the-catch">
+                  <SmartLink openInSameWindow={true} to="http://salad.com/blog/making-money-with-salad-whats-the-catch">
                     What's the Catch?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu">
+                  <SmartLink
+                    openInSameWindow={true}
+                    to="http://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu"
+                  >
                     Does mining hurt my machine?
                   </SmartLink>
                 </P>

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -110,28 +110,22 @@ class _MiningInformation extends Component<Props> {
                 <SectionHeader>More Information</SectionHeader>
                 <br />
                 <P>
-                  <SmartLink
-                    openInSameWindow={true}
-                    to="http://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus"
-                  >
+                  <SmartLink to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus">
                     Having Anti-Virus Issues?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink openInSameWindow={true} to="http://salad.com/blog/gamers-guide-blockchain-crypto">
+                  <SmartLink to="https://salad.com/blog/gamers-guide-blockchain-crypto">
                     Gamers Guide to Blockchain
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink openInSameWindow={true} to="http://salad.com/blog/making-money-with-salad-whats-the-catch">
+                  <SmartLink to="https://salad.com/blog/making-money-with-salad-whats-the-catch">
                     What's the Catch?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink
-                    openInSameWindow={true}
-                    to="http://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu"
-                  >
+                  <SmartLink to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu">
                     Does mining hurt my machine?
                   </SmartLink>
                 </P>

--- a/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
+++ b/packages/web-app/src/modules/earn-views/components/MiningInformation.tsx
@@ -110,31 +110,22 @@ class _MiningInformation extends Component<Props> {
                 <SectionHeader>More Information</SectionHeader>
                 <br />
                 <P>
-                  <SmartLink
-                    openInSameWindow={true}
-                    to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus"
-                  >
+                  <SmartLink to="https://support.salad.com/hc/en-us/sections/360008458292-Anti-Virus">
                     Having Anti-Virus Issues?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink openInSameWindow={true} to="https://salad.com/blog/gamers-guide-blockchain-crypto">
+                  <SmartLink to="https://salad.com/blog/gamers-guide-blockchain-crypto">
                     Gamers Guide to Blockchain
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink
-                    openInSameWindow={true}
-                    to="https://salad.com/blog/making-money-with-salad-whats-the-catch"
-                  >
+                  <SmartLink to="https://salad.com/blog/making-money-with-salad-whats-the-catch">
                     What's the Catch?
                   </SmartLink>
                 </P>
                 <P>
-                  <SmartLink
-                    openInSameWindow={true}
-                    to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu"
-                  >
+                  <SmartLink to="https://salad.com/blog/does-mining-for-cryptocurrency-damage-my-gpu">
                     Does mining hurt my machine?
                   </SmartLink>
                 </P>


### PR DESCRIPTION
We had a couple of links that were opening in new windows but we wanted them to open in the same window. 

I'm not super in love with the way I did this but because the base url is different, I couldn't just do a `to="/article"` which would open in the same window. I changed our `SmartLink` component to have an optional prop called `openInSameWindow` which removes the `target='_blank'`. This doesn't change the behavior of any of our existing `SmartLink` component uses.

Please let me know if there's another way you would prefer for this to work. 