### PR TITLE
Redirect legacy Top Chops links

### DIFF
--- a/packages/web-app/src/Routes.tsx
+++ b/packages/web-app/src/Routes.tsx
@@ -100,6 +100,19 @@ const _Routes = ({ location }: RouteComponentProps) => {
       )}
       {saladBowlEnabled && <DesktopRoute path="/earn/machine-settings" component={MachineSettingsPageContainer} />}
 
+      <Route
+        exact
+        path="/search"
+        component={({ location }: RouteComponentProps) => (
+          <Redirect
+            to={{
+              ...location,
+              pathname: `/store${location.pathname}`,
+            }}
+          />
+        )}
+      />
+      <Redirect exact from="/rewards/:id" to="/store/rewards/:id" />
       <Redirect exact from="/" to="/store" />
 
       <Route component={NotFoundPage} />


### PR DESCRIPTION
This sets up redirects for legacy Top Chops links. This enables compatibility for the links in both the alpha and non-alpha versions of the app.