### PR TITLE
Updates PhoenixMiner to 6.0c

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/phoenix-miner.tsx
@@ -2,6 +2,10 @@ const baseUrl = 'https://github.com/SaladTechnologies/plugin-downloads/releases/
 
 export const downloads = [
   {
+    version: '6.0c',
+    windowsUrl: baseUrl + '/phoenixminer-6-0c/phoenixminer-6-0c-windows.zip',
+  },
+  {
     version: '5.9d',
     windowsUrl: baseUrl + '/phoenixminer-5-9d/phoenixminer-5-9d-windows.zip',
   },


### PR DESCRIPTION
Updates PhoenixMiner to 6.0c. This release supports a basic implementation of an LHR unlock for most NVIDIA LHR GPU models. No additional argument changes are necessary, it should auto-detect LHR GPUs with a default unlock intensity.

Please also merge.