### PR TITLE
AV helpscout articles

### DIFF
--- a/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
@@ -23,6 +23,7 @@ const mapStoreToProps = (store: RootStore, ownProps: any): Omit<AntivirusGuidePr
     onCloseClicked: handleOnCloseClicked,
     antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
     articleId: ownProps.match.params.id,
+    helpScoutUrl: store.zendesk.helpScoutUrl,
     isNative: store.native.isNative,
     navigateToAVGuide: (antivirusSoftwareName: AntiVirusSoftware, label: string) =>
       store.onboardingAntivirus.navigateToAVGuide(antivirusSoftwareName, label),

--- a/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
@@ -213,7 +213,6 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
         <OnboardingAntiVirusScrollbar>
           <div className={classes.page}>
             <div className={classes.container}>
-              {console.log(helpScoutUrl)}
               <div className={classes.heading}>
                 <div className={classes.title}>
                   <Text variant="headline">{antivirusName}</Text>

--- a/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, Modal, Text } from '@saladtechnologies/garden-components'
 import { Component } from 'react'
 import withStyles, { WithStyles } from 'react-jss'
-import Skeleton from 'react-loading-skeleton'
 import { ModalPage } from '../../../components'
 import { SaladTheme } from '../../../SaladTheme'
 import { AntiVirusSoftware } from '../../zendesk/models'
@@ -88,6 +87,8 @@ const styles = (theme: SaladTheme) => ({
     lineHeight: '150%',
   },
   subtitle: {
+    marginTop: 16,
+    marginBottom: 8,
     fontSize: theme.medium,
   },
   '@keyframes fadeIn': {
@@ -129,6 +130,7 @@ export interface AntivirusGuideProps extends WithStyles<typeof styles> {
   navigateToAVGuide: (antivirusSoftwareName: AntiVirusSoftware, label: string) => void
   onNoAVClick: () => void
   articleId?: number
+  helpScoutUrl?: string
 }
 
 interface State {
@@ -198,17 +200,8 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
   }
 
   render() {
-    const {
-      antivirusName,
-      article,
-      loading,
-      onCloseClicked,
-      antiVirusGuideVideoId,
-      isNative,
-      navigateToAVGuide,
-      onNoAVClick,
-      classes,
-    } = this.props
+    const { antivirusName, onCloseClicked, isNative, navigateToAVGuide, onNoAVClick, classes, helpScoutUrl } =
+      this.props
 
     const { webWidgetShowing, showAVSelectionModal } = this.state
 
@@ -220,48 +213,26 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
         <OnboardingAntiVirusScrollbar>
           <div className={classes.page}>
             <div className={classes.container}>
-              {loading ? (
-                <Skeleton height={'100%'} />
-              ) : (
-                <>
-                  <div className={classes.heading}>
-                    <div className={classes.title}>
-                      <Text variant="headline">{antivirusName}</Text>
-                    </div>
-                    <div className={classes.subtitle}>
-                      <Text variant="baseS">
-                        Use a different anti-virus provider?{' '}
-                        <span className={classes.link} onClick={this.handleOpenAVSelectionModal}>
-                          Select it from this list
-                        </span>
-                        .
-                      </Text>
-                    </div>
-                  </div>
-                  {article ? (
-                    <>
-                      {antiVirusGuideVideoId && (
-                        <div className={classes.video}>
-                          <iframe
-                            title={antivirusName}
-                            src={`//player.vimeo.com/video/${antiVirusGuideVideoId}`}
-                            width="640"
-                            height="360"
-                            frameBorder="0"
-                            allowFullScreen
-                          ></iframe>
-                        </div>
-                      )}
-                      <Text variant="baseL">
-                        <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />{' '}
-                      </Text>
-                    </>
-                  ) : null}
-                  <span className={classes.closeButtonContainer}>
-                    <Button size="medium" label="Close" onClick={onCloseClicked} />
+              {console.log(helpScoutUrl)}
+              <div className={classes.heading}>
+                <div className={classes.title}>
+                  <Text variant="headline">{antivirusName}</Text>
+                </div>
+              </div>
+
+              <iframe width={700} height={700} title={antivirusName} src={helpScoutUrl} />
+              <div className={classes.subtitle}>
+                <Text variant="baseS">
+                  Use a different anti-virus provider?{' '}
+                  <span className={classes.link} onClick={this.handleOpenAVSelectionModal}>
+                    Select it from this list
                   </span>
-                </>
-              )}
+                  .
+                </Text>
+              </div>
+              <span className={classes.closeButtonContainer}>
+                <Button size="medium" label="Close" onClick={onCloseClicked} />
+              </span>
             </div>
           </div>
         </OnboardingAntiVirusScrollbar>

--- a/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
@@ -1,7 +1,6 @@
 import { action, flow, observable } from 'mobx'
 import { RootStore } from '../../Store'
 import { delay, routeLink } from '../../utils'
-import type { ZendeskArticleResource } from '../zendesk/models'
 import { AntiVirusSoftware } from '../zendesk/models'
 import { getZendeskAVData } from '../zendesk/utils'
 import { ONBOARDING_PAGE_NAMES, WhitelistWindowsDefenderErrorTypeMessage } from './models'
@@ -139,26 +138,9 @@ export class OnboardingAntivirusStore {
   }
 
   @action.bound
-  loadArticle = flow(
-    function* (this: OnboardingAntivirusStore, articleID: number) {
-      const antivirusSoftwareName = getZendeskAVData(articleID).name
-      this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
-      if (antivirusSoftwareName === this.selectedAntiVirusGuide && this.helpCenterArticle !== undefined) {
-        return
-      }
-
-      this.loadingArticle = true
-      try {
-        let res: Response = yield fetch(`https://salad.zendesk.com/api/v2/help_center/en-us/articles/${articleID}`, {
-          credentials: 'omit',
-        })
-        const data: ZendeskArticleResource = yield res.json()
-        this.helpCenterArticle = data.article.body
-        this.selectedAntiVirusGuide = antivirusSoftwareName
-      } catch (err) {
-        throw err
-      }
-      this.loadingArticle = false
-    }.bind(this),
-  )
+  loadArticle = function (this: OnboardingAntivirusStore, articleID: number) {
+    this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
+    this.store.zendesk.helpScoutUrl = getZendeskAVData(articleID).helpScoutUrl
+    this.selectedAntiVirusGuide = getZendeskAVData(articleID).name
+  }.bind(this)
 }

--- a/packages/web-app/src/modules/zendesk/Zendesk.ts
+++ b/packages/web-app/src/modules/zendesk/Zendesk.ts
@@ -43,6 +43,8 @@ export class Zendesk {
   @observable
   public antiVirusGuideVideoId?: number
 
+  @observable helpScoutUrl?: string
+
   private readonly useZendesk: boolean
 
   constructor(

--- a/packages/web-app/src/modules/zendesk/utils.ts
+++ b/packages/web-app/src/modules/zendesk/utils.ts
@@ -37,6 +37,7 @@ interface ZendeskAVData {
   id?: number
   name?: AntiVirusSoftware
   videoId?: number
+  helpScoutUrl?: string
 }
 
 export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number): ZendeskAVData => {
@@ -46,155 +47,185 @@ export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number
     case AntiVirusSoftware.Adaware:
     case 360041688612:
       zendeskAVData.id = 360041688612
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/148-how-to-whitelist-salad-in-adaware`
       zendeskAVData.name = AntiVirusSoftware.Adaware
       break
     case AntiVirusSoftware.AdvancedSystemCareUltimate:
     case 360042137651:
       zendeskAVData.id = 360042137651
       zendeskAVData.name = AntiVirusSoftware.AdvancedSystemCareUltimate
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/149-how-to-whitelist-salad-in-advanced-systemcare-ultimate`
       break
     case AntiVirusSoftware.Avast:
     case 360033487211:
       zendeskAVData.id = 360033487211
       zendeskAVData.name = AntiVirusSoftware.Avast
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/144-how-to-whitelist-salad-in-avast-antivirus`
       zendeskAVData.videoId = 574387141
       break
     case AntiVirusSoftware.AVG:
     case 360041706612:
       zendeskAVData.id = 360041706612
       zendeskAVData.name = AntiVirusSoftware.AVG
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/150-how-to-whitelist-salad-in-avg`
       break
     case AntiVirusSoftware.Avira:
     case 360042139651:
       zendeskAVData.id = 360042139651
       zendeskAVData.name = AntiVirusSoftware.Avira
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/151-how-to-whitelist-salad-in-avira`
       break
     case AntiVirusSoftware.BitDefender:
     case 360033488151:
       zendeskAVData.id = 360033488151
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/145-how-to-whitelist-salad-in-bitdefender-antivirus-plus`
       zendeskAVData.name = AntiVirusSoftware.BitDefender
       break
     case AntiVirusSoftware.BullGuard:
     case 360041708232:
       zendeskAVData.id = 360041708232
       zendeskAVData.name = AntiVirusSoftware.BullGuard
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/152-how-to-whitelist-salad-in-bullguard`
       break
     case AntiVirusSoftware.Comodo:
     case 360041713452:
       zendeskAVData.id = 360041713452
       zendeskAVData.name = AntiVirusSoftware.Comodo
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/153-how-to-whitelist-salad-in-comodo`
       break
     case AntiVirusSoftware.EScan:
     case 360041720452:
       zendeskAVData.id = 360041720452
       zendeskAVData.name = AntiVirusSoftware.EScan
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/154-how-to-whitelist-salad-in-e-scan`
       break
     case AntiVirusSoftware.ESETNOD32:
     case 360041721632:
       zendeskAVData.id = 360041721632
       zendeskAVData.name = AntiVirusSoftware.ESETNOD32
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/155-how-to-whitelist-salad-in-eset-nod32`
       break
     case AntiVirusSoftware.FProt:
     case 360042153731:
       zendeskAVData.id = 360042153731
       zendeskAVData.name = AntiVirusSoftware.FProt
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/156-how-to-whitelist-salad-in-f-prot`
       break
     case AntiVirusSoftware.FSecure:
     case 360042154431:
       zendeskAVData.id = 360042154431
       zendeskAVData.name = AntiVirusSoftware.FSecure
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/157-how-to-whitelist-salad-in-f-secure`
       break
     case AntiVirusSoftware.GData:
     case 360042154771:
       zendeskAVData.id = 360042154771
       zendeskAVData.name = AntiVirusSoftware.GData
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/158-how-to-whitelist-salad-in-gdata`
       break
     case AntiVirusSoftware.K7:
     case 360041736392:
       zendeskAVData.id = 360041736392
       zendeskAVData.name = AntiVirusSoftware.K7
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/159-how-to-whitelist-salad-in-k7`
       break
     case AntiVirusSoftware.Kaspersky:
     case 360042167171:
       zendeskAVData.id = 360042167171
       zendeskAVData.name = AntiVirusSoftware.Kaspersky
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/160-how-to-whitelist-salad-in-kaspersky`
       break
     case AntiVirusSoftware.Malwarebytes:
     case 360031870772:
       zendeskAVData.id = 360031870772
       zendeskAVData.name = AntiVirusSoftware.Malwarebytes
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/141-how-to-whitelist-salad-in-malwarebytes`
       break
     case AntiVirusSoftware.McAfeeSecurity:
     case 360033488271:
       zendeskAVData.id = 360033488271
       zendeskAVData.name = AntiVirusSoftware.McAfeeSecurity
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/146-how-to-whitelist-salad-in-mcafee`
       zendeskAVData.videoId = 575421455
       break
     case AntiVirusSoftware.Norton:
     case 360032211151:
       zendeskAVData.id = 360032211151
       zendeskAVData.name = AntiVirusSoftware.Norton
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/142-how-to-whitelist-salad-in-norton-antivirus`
       break
     case AntiVirusSoftware.Panda:
     case 360033488451:
       zendeskAVData.id = 360033488451
       zendeskAVData.name = AntiVirusSoftware.Panda
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/147-how-to-whitelist-salad-in-panda`
       break
     case AntiVirusSoftware.PCMatic:
     case 360042169891:
       zendeskAVData.id = 360042169891
       zendeskAVData.name = AntiVirusSoftware.PCMatic
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/161-how-to-whitelist-salad-in-pcmatic`
       break
     case AntiVirusSoftware.Qihoo360:
     case 360042222471:
       zendeskAVData.id = 360042222471
       zendeskAVData.name = AntiVirusSoftware.Qihoo360
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/162-how-to-whitelist-salad-in-qihoo-360`
       break
     case AntiVirusSoftware.SecureAgeAPEX:
     case 360041801812:
       zendeskAVData.id = 360041801812
       zendeskAVData.name = AntiVirusSoftware.SecureAgeAPEX
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/163-how-to-whitelist-salad-in-secureage-apex`
       break
     case AntiVirusSoftware.Sophos:
     case 360041802092:
       zendeskAVData.id = 360041802092
       zendeskAVData.name = AntiVirusSoftware.Sophos
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/164-how-to-whitelist-salad-in-sophos`
       break
     case AntiVirusSoftware.TotalAV:
     case 360041802372:
       zendeskAVData.id = 360041802372
       zendeskAVData.name = AntiVirusSoftware.TotalAV
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/165-how-to-whitelist-salad-in-totalav`
       break
     case AntiVirusSoftware.TrendMicro:
     case 360042223291:
       zendeskAVData.id = 360042223291
       zendeskAVData.name = AntiVirusSoftware.TrendMicro
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/166-how-to-whitelist-salad-in-trendmicro`
       break
     case AntiVirusSoftware.Twister:
     case 360042223891:
       zendeskAVData.id = 360042223891
       zendeskAVData.name = AntiVirusSoftware.Twister
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/167-how-to-whitelist-salad-in-twister`
       break
     case AntiVirusSoftware.VIPRE:
     case 360041803732:
       zendeskAVData.id = 360041803732
       zendeskAVData.name = AntiVirusSoftware.VIPRE
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/168-how-to-whitelist-salad-in-vipre`
       break
     case AntiVirusSoftware.Webroot:
     case 360041804212:
       zendeskAVData.id = 360041804212
       zendeskAVData.name = AntiVirusSoftware.Webroot
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/169-how-to-whitelist-salad-in-webroot`
       break
     case AntiVirusSoftware.WindowsDefender:
     case 360033124692:
       zendeskAVData.id = 360033124692
       zendeskAVData.name = AntiVirusSoftware.WindowsDefender
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/143-how-to-whitelist-salad-in-windows-defender`
       zendeskAVData.videoId = 574423693
       break
     case AntiVirusSoftware.Zillya:
     case 360042225091:
       zendeskAVData.id = 360042225091
       zendeskAVData.name = AntiVirusSoftware.Zillya
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/170-how-to-whitelist-salad-in-zillya`
       break
   }
 


### PR DESCRIPTION
Just a quick fix for making sure our AV guides are being displayed for now. I only touched what I needed to get this fix out the door. We're going to need to eventually come back and rip out all this zendesk stuff and come up with a more permanent solution.  

From what I could tell after checking the routes, the only articles we were displaying from zendesk were the AV ones.

![image](https://user-images.githubusercontent.com/37646831/158447327-01dbc880-98e5-490c-b77f-9a0c94733184.png)
http://localhost:3000/onboarding/antivirus-guide/360033124692
![image](https://user-images.githubusercontent.com/37646831/158447350-40acef45-1c93-4914-837c-4aa75a11baaf.png)
http://localhost:3000/onboarding/antivirus-guide/360042153731