### PR TITLE
Loading Helpscout AV articles

### DIFF
--- a/packages/web-app/src/modules/error-views/FirewallErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/FirewallErrorContainer.ts
@@ -11,6 +11,7 @@ const mapStoreToProps = (store: RootStore): any => {
     loading: store.zendesk.loadingArticle,
     loadArticle: () => store.zendesk.loadFirewallArticle(),
     onCloseClicked: () => store.ui.hideModal(true),
+    helpScoutFirewallArticle: store.zendesk.helpScoutFirewallArticle,
   }
 }
 

--- a/packages/web-app/src/modules/error-views/GenericAntiVirusErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/GenericAntiVirusErrorContainer.ts
@@ -16,6 +16,7 @@ const mapStoreToProps = (store: RootStore): any => {
     onCloseClicked: () => store.ui.hideModal(true),
     onViewAVList: () => store.routing.push('/errors/anti-virus'),
     onViewArticle: (id: number) => onViewArticle(id),
+    helpScoutAntiVirusList: store.zendesk.helpScoutAntiVirusList,
   }
 }
 

--- a/packages/web-app/src/modules/error-views/GenericAntiVirusErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/GenericAntiVirusErrorContainer.ts
@@ -1,11 +1,15 @@
 import { connect } from '../../connect'
 import { RootStore } from '../../Store'
+import { getZendeskAVData } from '../zendesk/utils'
 import { AntiVirusFirewallErrorPage } from './components/AntiVirusFirewallErrorPage'
 
 const mapStoreToProps = (store: RootStore): any => {
-  const onViewArticle = (id: number) => {
-    store.ui.showModal(`/errors/anti-virus/${id}`)
-    store.ui.trackAntiVirusGuideLinkClick(id)
+  const onViewArticle = (name: string) => {
+    const id = getZendeskAVData(name).id
+    if (id) {
+      store.ui.showModal(`/errors/anti-virus/${id}`)
+      store.ui.trackAntiVirusGuideLinkClick(id)
+    }
   }
   return {
     errorType: store.zendesk.errorType,
@@ -15,8 +19,7 @@ const mapStoreToProps = (store: RootStore): any => {
     loadArticle: () => store.zendesk.loadAntiVirusArticleList(),
     onCloseClicked: () => store.ui.hideModal(true),
     onViewAVList: () => store.routing.push('/errors/anti-virus'),
-    onViewArticle: (id: number) => onViewArticle(id),
-    helpScoutAntiVirusList: store.zendesk.helpScoutAntiVirusList,
+    onViewArticle: (name: string) => onViewArticle(name),
   }
 }
 

--- a/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
@@ -1,19 +1,16 @@
 import { withRouter } from 'react-router'
 import { connect } from '../../connect'
 import { RootStore } from '../../Store'
-import { getSanitizedHTML } from '../../utils'
 import { AntiVirusFirewallErrorPage } from './components/AntiVirusFirewallErrorPage'
 
 const mapStoreToProps = (store: RootStore, ownProps: any): any => ({
   errorType: store.zendesk.errorType,
   antivirusName: store.zendesk.selectedAntiVirusGuide,
-  article: store.zendesk.helpCenterArticle ? getSanitizedHTML(store.zendesk.helpCenterArticle) : undefined,
   fallthrough: store.ui.hasViewedAVErrorPage,
   loading: store.zendesk.loadingArticle,
   loadArticle: () => store.zendesk.loadArticle(parseInt(ownProps.match.params.id)),
   onCloseClicked: () => store.ui.hideModal(),
   onViewAVList: () => store.routing.push('/errors/anti-virus'),
-  antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
   helpScoutUrl: store.zendesk.helpScoutUrl,
 })
 

--- a/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
+++ b/packages/web-app/src/modules/error-views/SpecificAntiVirusErrorContainer.ts
@@ -14,6 +14,7 @@ const mapStoreToProps = (store: RootStore, ownProps: any): any => ({
   onCloseClicked: () => store.ui.hideModal(),
   onViewAVList: () => store.routing.push('/errors/anti-virus'),
   antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
+  helpScoutUrl: store.zendesk.helpScoutUrl,
 })
 
 export const SpecificAntiVirusErrorContainer = withRouter(connect(mapStoreToProps, AntiVirusFirewallErrorPage))

--- a/packages/web-app/src/modules/error-views/components/AntiVirusErrorPage.stories.tsx
+++ b/packages/web-app/src/modules/error-views/components/AntiVirusErrorPage.stories.tsx
@@ -3,6 +3,7 @@ import { linkTo } from '@storybook/addon-links'
 import { storiesOf } from '@storybook/react'
 import { ErrorPageType } from '../../../UIStore'
 import { getSanitizedHTML } from '../../../utils'
+import { antivirusInfo } from '../../zendesk/utils'
 import { AntiVirusFirewallErrorPage } from './AntiVirusFirewallErrorPage'
 
 storiesOf('Modules/Error Pages/Pages', module)
@@ -36,7 +37,7 @@ storiesOf('Modules/Error Pages/Pages', module)
     return (
       <AntiVirusFirewallErrorPage
         errorType={ErrorPageType.AntiVirus}
-        articleList={articleList}
+        articleList={antivirusInfo}
         onCloseClicked={action('On Close Clicked')}
         onViewArticle={linkTo('Modules/Error Pages/Pages', 'Specific Anti-Virus Error - Initial')}
         onViewAVList={linkTo('Modules/Error Pages/Pages', 'Generic Anti-Virus Error - Initial')}
@@ -47,7 +48,7 @@ storiesOf('Modules/Error Pages/Pages', module)
     return (
       <AntiVirusFirewallErrorPage
         errorType={ErrorPageType.AntiVirus}
-        articleList={articleList}
+        articleList={antivirusInfo}
         onCloseClicked={action('On Close Clicked')}
         fallthrough={true}
         onViewArticle={linkTo('Modules/Error Pages/Pages', 'Specific Anti-Virus Error - Initial')}
@@ -82,86 +83,3 @@ const specificAntiVirusArticle = getSanitizedHTML(kasperskyBody)
 const firewallBody =
   '<ol><li> Open Windows Security.<img src="https://support.salad.com/hc/article_attachments/360089893631/mceclip0.png" alt="mceclip0.png"></li><li>Navigate to Firewall &amp; network protection.<img src="https://support.salad.com/hc/article_attachments/360090201211/FIREWALL_GUIDE_IMAGE_2.png" alt="FIREWALL_GUIDE_IMAGE_2.png"></li><li>Scroll down to Allow an app through firewall.<img src="https://support.salad.com/hc/article_attachments/360090201191/FIREWALLGUIDE_IMAGE_3.png" alt="FIREWALLGUIDE_IMAGE_3.png"></li><li>Scroll down until you find the affected miner.<img src="https://support.salad.com/hc/article_attachments/360090201271/FIREWALL_GUIDE_IMAGE_4.png" alt="FIREWALL_GUIDE_IMAGE_4.png"></li><li>Click Change settings at the top right, and click all the tick boxes on the right side, as well as left side, of the affected miner. Do the same for any further firewall blocked affected miners, if you see the same item listed multiple times, make sure to allow all of them through. Then click OK.</li></ol><p> </p><p>If you are using another Firewall service, please consult their website or support for details on how to allow applications or services through your Firewall.</p>'
 const firewallArticle = getSanitizedHTML(firewallBody)
-
-const articleList = [
-  {
-    id: 1,
-    name: 'How to Whitelist Salad in Windows Defender',
-  },
-  {
-    id: 2,
-    name: 'How to whitelist Salad in McAfee',
-  },
-  {
-    id: 3,
-    name: 'How to Whitelist Salad in Avast Antivirus',
-  },
-  {
-    id: 4,
-    name: 'How to Whitelist Salad in Norton Antivirus',
-  },
-  {
-    id: 5,
-    name: 'How to Whitelist Salad in Malwarebytes',
-  },
-  {
-    id: 6,
-    name: 'How to Whitelist Salad in AVG',
-  },
-  {
-    id: 7,
-    name: 'How to Whitelist Salad in Kaspersky',
-  },
-  {
-    id: 8,
-    name: 'How to Whitelist Salad in Zillya',
-  },
-  {
-    id: 9,
-    name: 'How to Whitelist Salad in Webroot',
-  },
-  {
-    id: 10,
-    name: 'How to Whitelist Salad in VIPRE',
-  },
-  {
-    id: 11,
-    name: 'How to Whitelist Salad in Twister',
-  },
-  {
-    id: 12,
-    name: 'How to Whitelist Salad in TrendMicro',
-  },
-  {
-    id: 13,
-    name: 'How to Whitelist Salad in TotalAV',
-  },
-  {
-    id: 14,
-    name: 'How to Whitelist Salad in Sophos',
-  },
-  {
-    id: 15,
-    name: 'How to Whitelist Salad in SecureAge APEX',
-  },
-  {
-    id: 16,
-    name: 'How to Whitelist Salad in Qihoo-360',
-  },
-  {
-    id: 17,
-    name: 'How to Whitelist Salad in PCMatic',
-  },
-  {
-    id: 18,
-    name: 'How to Whitelist Salad in K7',
-  },
-  {
-    id: 19,
-    name: 'How to Whitelist Salad in GData',
-  },
-  {
-    id: 20,
-    name: 'How to Whitelist Salad in F-Secure',
-  },
-]

--- a/packages/web-app/src/modules/error-views/components/AntiVirusErrorPage.stories.tsx
+++ b/packages/web-app/src/modules/error-views/components/AntiVirusErrorPage.stories.tsx
@@ -2,7 +2,6 @@ import { action } from '@storybook/addon-actions'
 import { linkTo } from '@storybook/addon-links'
 import { storiesOf } from '@storybook/react'
 import { ErrorPageType } from '../../../UIStore'
-import { getSanitizedHTML } from '../../../utils'
 import { antivirusInfo } from '../../zendesk/utils'
 import { AntiVirusFirewallErrorPage } from './AntiVirusFirewallErrorPage'
 
@@ -15,7 +14,6 @@ storiesOf('Modules/Error Pages/Pages', module)
       <AntiVirusFirewallErrorPage
         errorType={ErrorPageType.AntiVirus}
         antivirusName="Kaspersky"
-        article={specificAntiVirusArticle}
         onCloseClicked={action('On Close Clicked')}
         onViewAVList={linkTo('Modules/Error Pages/Pages', 'Generic Anti-Virus Error - Initial')}
       />
@@ -26,7 +24,6 @@ storiesOf('Modules/Error Pages/Pages', module)
       <AntiVirusFirewallErrorPage
         errorType={ErrorPageType.AntiVirus}
         antivirusName="Kaspersky"
-        article={specificAntiVirusArticle}
         fallthrough={true}
         onCloseClicked={action('On Close Clicked')}
         onViewAVList={linkTo('Modules/Error Pages/Pages', 'Generic Anti-Virus Error - Initial')}
@@ -57,29 +54,14 @@ storiesOf('Modules/Error Pages/Pages', module)
     )
   })
   .add('Firewall Error - Initial', () => {
-    return (
-      <AntiVirusFirewallErrorPage
-        errorType={ErrorPageType.Firewall}
-        article={firewallArticle}
-        onCloseClicked={action('On Close Clicked')}
-      />
-    )
+    return <AntiVirusFirewallErrorPage errorType={ErrorPageType.Firewall} onCloseClicked={action('On Close Clicked')} />
   })
   .add('Firewall Error - Fallthrough', () => {
     return (
       <AntiVirusFirewallErrorPage
         errorType={ErrorPageType.Firewall}
         fallthrough={true}
-        article={firewallArticle}
         onCloseClicked={action('On Close Clicked')}
       />
     )
   })
-
-const kasperskyBody =
-  '<h3> 1. Uninstall Salad</h3>\n<p><strong><span style="font-weight: 400;">Uninstall Salad, and all of its associated files and folders</span></strong></p>\n<h3>2. Restart your computer</h3>\n<p><strong><span style="font-weight: 400;">This will finalize the uninstallation of Salad, as it does with most programs that require drivers to run.</span></strong></p>\n<h3>3. Reinstall Salad</h3>\n<p><strong><span style="font-weight: 400;">Navigate in your internet browser to </span><a href="http://salad.com"><span style="font-weight: 400;">salad.com</span></a><span style="font-weight: 400;"> and re-download the installation .exe, and when the installation finishes, be sure to uncheck the “Run Salad” checkbox.</span></strong></p>\n<h3><span style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Helvetica, Arial, sans-serif;">4. Open <span class="wysiwyg-font-size-large">Kaspersky</span></span></h3>\n<p><span style="font-weight: 400;">This will be the main screen you are presented within Kaspersky, and is your base of virus-fighting operations.</span></p>\n<p><img src="https://support.salad.com/hc/article_attachments/360054487791/unnamed__4_.png" alt="unnamed__4_.png"></p>\n<h3>5. Navigate to Settings</h3>\n<p><span style="font-weight: 400;">Click the gear icon on the bottom left corner to access your settings.</span></p>\n<p><img src="https://support.salad.com/hc/article_attachments/360054348672/unnamed__3_.png" alt="unnamed__3_.png"></p>\n<h3>6. Click on Additional</h3>\n<p><span style="font-weight: 400;">After clicking ‘Threats and Exclusions’ settings you will be greeted with a new popup. From that popup, select ‘Manage Exclusions’</span></p>\n<p><img src="https://support.salad.com/hc/article_attachments/360054348692/unnamed__2_.png" alt="unnamed__2_.png"></p>\n<h3>7. Click on \'Threats and Exclusions\'</h3>\n<p><span style="font-weight: 400;">After clicking ‘Threats and Exclusions’ settings you will be greeted with a new popup. From that popup, select ‘Manage Exclusions’</span></p>\n<p><img src="https://support.salad.com/hc/article_attachments/360054348712/unnamed__1_.png" alt="unnamed__1_.png"></p>\n<h3>8. Click on ‘Add’</h3>\n<p><span style="font-weight: 400;">After clicking ‘Manage Exclusions’ you will be greeted with another box. Click ‘Add’ on that box as pictured below</span></p>\n<p> <img src="https://support.salad.com/hc/article_attachments/360054348732/unnamed.png" alt="unnamed.png"></p>\n<p> </p>\n<h3>9. Adding Salad as Whitelist</h3>\n<p><span style="font-weight: 400;">After clicking ‘Add’ you will be greeted with another dialogue box. Under the ‘File and Folder’ option,  you’ll want to navigate to the Salad installation folder and select it, the default installation path is “C:\\Users\\YourUserHere\\AppData\\Roaming\\Salad” (without the quotations) and click on ‘Add’.</span></p>\n<p><img src="https://support.salad.com/hc/article_attachments/360054487811/unnamed__7_.png" alt="unnamed__7_.png"></p>\n<p> </p>\n<p> </p>\n<h3>10. Click \'Add\'</h3>\n<p><span style="font-weight: 400;">Once you’ve found your Salad installation folder and clicked it, hit Add, and it will bring you back to the main Kaspersky Exclusions whitelist page with your newly added exclusion.</span></p>\n<p> </p>\n<h3>11. Run Salad</h3>\n<p><span style="font-weight: 400;">Let Salad run for at least 30 minutes after setting up the whitelist. Contact support if this issue persists.</span></p>'
-const specificAntiVirusArticle = getSanitizedHTML(kasperskyBody)
-
-const firewallBody =
-  '<ol><li> Open Windows Security.<img src="https://support.salad.com/hc/article_attachments/360089893631/mceclip0.png" alt="mceclip0.png"></li><li>Navigate to Firewall &amp; network protection.<img src="https://support.salad.com/hc/article_attachments/360090201211/FIREWALL_GUIDE_IMAGE_2.png" alt="FIREWALL_GUIDE_IMAGE_2.png"></li><li>Scroll down to Allow an app through firewall.<img src="https://support.salad.com/hc/article_attachments/360090201191/FIREWALLGUIDE_IMAGE_3.png" alt="FIREWALLGUIDE_IMAGE_3.png"></li><li>Scroll down until you find the affected miner.<img src="https://support.salad.com/hc/article_attachments/360090201271/FIREWALL_GUIDE_IMAGE_4.png" alt="FIREWALL_GUIDE_IMAGE_4.png"></li><li>Click Change settings at the top right, and click all the tick boxes on the right side, as well as left side, of the affected miner. Do the same for any further firewall blocked affected miners, if you see the same item listed multiple times, make sure to allow all of them through. Then click OK.</li></ol><p> </p><p>If you are using another Firewall service, please consult their website or support for details on how to allow applications or services through your Firewall.</p>'
-const firewallArticle = getSanitizedHTML(firewallBody)

--- a/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
+++ b/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
@@ -1,12 +1,12 @@
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import type { ReactChild } from 'react'
 import { Component } from 'react'
 import withStyles, { WithStyles } from 'react-jss'
 import Skeleton from 'react-loading-skeleton'
 import { Button, InfoButton, ModalPage, SmartLink } from '../../../components'
 import { SaladTheme } from '../../../SaladTheme'
 import { ErrorPageType } from '../../../UIStore'
+import { antivirusInfo } from '../../zendesk/utils'
 import { AntiVirusFirewallScrollbar } from './AntiVirusFirewallScrollbar'
 
 const styles = (theme: SaladTheme) => ({
@@ -122,26 +122,17 @@ const styles = (theme: SaladTheme) => ({
   },
 })
 
-interface HelpCenterArticle {
-  name: string
-  id: number
-}
-
 interface Props extends WithStyles<typeof styles> {
   antivirusName?: string
   errorType: string
-  article?: string
-  articleList?: HelpCenterArticle[]
-  bottomMessage?: ReactChild
+  articleList?: typeof antivirusInfo
   fallthrough?: boolean
   loading?: boolean
   loadArticle?: () => void
   onCloseClicked?: () => void
-  onViewArticle?: (id: number) => void
+  onViewArticle?: (name: string) => void
   onViewAVList?: () => void
-  antiVirusGuideVideoId?: number
   helpScoutFirewallArticle?: string
-  helpScoutAntiVirusList?: string
   helpScoutUrl?: string
 }
 
@@ -197,7 +188,8 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
       onCloseClicked,
       onViewAVList,
       helpScoutFirewallArticle,
-      helpScoutAntiVirusList,
+      onViewArticle,
+      articleList,
       helpScoutUrl,
       classes,
     } = this.props
@@ -296,7 +288,17 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
                       {antivirusName ? (
                         <iframe height={700} width={700} src={helpScoutUrl} title={antivirusName} />
                       ) : (
-                        <iframe height={700} width={700} src={helpScoutAntiVirusList} title="AV Guide List" />
+                        <ul className={classes.list}>
+                          {articleList?.map((article) => (
+                            <li
+                              key={article.label}
+                              className={classes.listItem}
+                              onClick={() => onViewArticle && onViewArticle(article.name)}
+                            >
+                              How to Whitelist Salad in {article.name}
+                            </li>
+                          ))}
+                        </ul>
                       )}
                       <Button onClick={onCloseClicked}>Close</Button>
                     </>

--- a/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
+++ b/packages/web-app/src/modules/error-views/components/AntiVirusFirewallErrorPage.tsx
@@ -140,6 +140,9 @@ interface Props extends WithStyles<typeof styles> {
   onViewArticle?: (id: number) => void
   onViewAVList?: () => void
   antiVirusGuideVideoId?: number
+  helpScoutFirewallArticle?: string
+  helpScoutAntiVirusList?: string
+  helpScoutUrl?: string
 }
 
 interface State {
@@ -189,14 +192,13 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
     const {
       antivirusName,
       errorType,
-      article,
-      articleList,
       fallthrough,
       loading,
       onCloseClicked,
-      onViewArticle,
       onViewAVList,
-      antiVirusGuideVideoId,
+      helpScoutFirewallArticle,
+      helpScoutAntiVirusList,
+      helpScoutUrl,
       classes,
     } = this.props
 
@@ -244,7 +246,8 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
                                   <p>
                                     Your anti-virus software is still blocking Salad, and none of our miners will work
                                     until you whitelist Salad with {antivirusName}. Reach out to the{' '}
-                                    <SmartLink to="https://www.reddit.com/r/SaladChefs">support forum</SmartLink> for help!
+                                    <SmartLink to="https://www.reddit.com/r/SaladChefs">support forum</SmartLink> for
+                                    help!
                                   </p>
                                   <p className={classes.selectFromList}>
                                     {' '}
@@ -259,7 +262,8 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
                                 <p>
                                   Your anti-virus has blocked all of our miners. so you'll need to whitelist Salad with
                                   your anti-virus in order to get chopping. Reach out to the{' '}
-                                  <SmartLink to="https://www.reddit.com/r/SaladChefs">support forum</SmartLink> for help!
+                                  <SmartLink to="https://www.reddit.com/r/SaladChefs">support forum</SmartLink> for
+                                  help!
                                 </p>
                               )}
                             </>
@@ -289,31 +293,11 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
                           )}
                         </div>
                       </div>
-                      {article ? (
-                        <>
-                          {antiVirusGuideVideoId && (
-                            <>
-                              <iframe
-                                title={antivirusName}
-                                src={`//player.vimeo.com/video/${antiVirusGuideVideoId}`}
-                                width="640"
-                                height="360"
-                                frameBorder="0"
-                                allowFullScreen
-                              ></iframe>
-                            </>
-                          )}
-                          <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />{' '}
-                        </>
-                      ) : articleList && onViewArticle ? (
-                        <ul className={classes.list}>
-                          {articleList.map((article) => (
-                            <li key={article.id} className={classes.listItem} onClick={() => onViewArticle(article.id)}>
-                              {article.name}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
+                      {antivirusName ? (
+                        <iframe height={700} width={700} src={helpScoutUrl} title={antivirusName} />
+                      ) : (
+                        <iframe height={700} width={700} src={helpScoutAntiVirusList} title="AV Guide List" />
+                      )}
                       <Button onClick={onCloseClicked}>Close</Button>
                     </>
                   )}
@@ -336,45 +320,39 @@ class _AntiVirusFirewallErrorPage extends Component<Props, State> {
             <AntiVirusFirewallScrollbar>
               <div className={classes.page}>
                 <div className={classes.container}>
-                  {loading ? (
-                    <Skeleton height={'100%'} />
-                  ) : (
-                    <>
-                      <div className={classes.heading}>
-                        <div className={classes.title}>
-                          {fallthrough ? (
-                            <h1>Add Exception for Salad to your Firewall</h1>
-                          ) : (
-                            <h1>Firewall is blocking Salad</h1>
-                          )}
-                          <InfoButton
-                            className={classes.tooltip}
-                            text={
-                              "Don't worry! Most Firewalls block cryptominers. This is to protect you from having other people install miners on your computer without you knowing - a process called 'cryptojacking'. As long as you are allowed to use this machine, you're fine! Check out the Salad blog to learn more."
-                            }
-                          />
-                        </div>
-                        <div className={classes.subtitle}>
-                          {fallthrough ? (
-                            <p>
-                              Your Firewall is still blocking Salad, and none of our miners will work until this issue
-                              is resolved. Can't add an exception? Reach out to the{' '}
-                              <SmartLink to="https://www.reddit.com/r/SaladChefs">Support Forum</SmartLink> for help!
-                            </p>
-                          ) : (
-                            <p>
-                              Your Firewall is blocking you from chopping. We'll keep testing other miners, but your
-                              earning rates could be lower until this issue is resolved.
-                            </p>
-                          )}
-                        </div>
+                  <>
+                    <div className={classes.heading}>
+                      <div className={classes.title}>
+                        {fallthrough ? (
+                          <h1>Add Exception for Salad to your Firewall</h1>
+                        ) : (
+                          <h1>Firewall is blocking Salad</h1>
+                        )}
+                        <InfoButton
+                          className={classes.tooltip}
+                          text={
+                            "Don't worry! Most Firewalls block cryptominers. This is to protect you from having other people install miners on your computer without you knowing - a process called 'cryptojacking'. As long as you are allowed to use this machine, you're fine! Check out the Salad blog to learn more."
+                          }
+                        />
                       </div>
-                      {article ? (
-                        <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />
-                      ) : null}
-                      <Button onClick={onCloseClicked}>Close</Button>
-                    </>
-                  )}
+                      <div className={classes.subtitle}>
+                        {fallthrough ? (
+                          <p>
+                            Your Firewall is still blocking Salad, and none of our miners will work until this issue is
+                            resolved. Can't add an exception? Reach out to the{' '}
+                            <SmartLink to="https://www.reddit.com/r/SaladChefs">Support Forum</SmartLink> for help!
+                          </p>
+                        ) : (
+                          <p>
+                            Your Firewall is blocking you from chopping. We'll keep testing other miners, but your
+                            earning rates could be lower until this issue is resolved.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <iframe height={700} width={700} src={helpScoutFirewallArticle} title="firewall article" />
+                    <Button onClick={onCloseClicked}>Close</Button>
+                  </>
                 </div>
               </div>
             </AntiVirusFirewallScrollbar>

--- a/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
@@ -23,6 +23,7 @@ const mapStoreToProps = (store: RootStore, ownProps: any): Omit<AntivirusGuidePr
     onCloseClicked: handleOnCloseClicked,
     antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
     articleId: ownProps.match.params.id,
+    helpScoutUrl: store.zendesk.helpScoutUrl,
     isNative: store.native.isNative,
     navigateToAVGuide: (antivirusSoftwareName: AntiVirusSoftware, label: string) =>
       store.onboardingAntivirus.navigateToAVGuide(antivirusSoftwareName, label),

--- a/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
+++ b/packages/web-app/src/modules/onboarding-views/OnboardingSpecificAntivirusGuideContainer.tsx
@@ -1,6 +1,5 @@
 import { connect } from '../../connect'
 import { RootStore } from '../../Store'
-import { getSanitizedHTML } from '../../utils'
 import { ONBOARDING_PAGE_NAMES } from '../onboarding/models'
 import { AntiVirusSoftware } from '../zendesk/models'
 import { AntivirusGuide, AntivirusGuideProps } from './pages/AntivirusGuide'
@@ -15,13 +14,8 @@ const mapStoreToProps = (store: RootStore, ownProps: any): Omit<AntivirusGuidePr
 
   return {
     antivirusName: store.onboardingAntivirus.selectedAntiVirusGuide,
-    article: store.onboardingAntivirus.helpCenterArticle
-      ? getSanitizedHTML(store.onboardingAntivirus.helpCenterArticle)
-      : undefined,
-    loading: store.onboardingAntivirus.loadingArticle,
     loadArticle: () => store.onboardingAntivirus.loadArticle(parseInt(ownProps.match.params.id)),
     onCloseClicked: handleOnCloseClicked,
-    antiVirusGuideVideoId: store.zendesk.antiVirusGuideVideoId,
     articleId: ownProps.match.params.id,
     helpScoutUrl: store.zendesk.helpScoutUrl,
     isNative: store.native.isNative,

--- a/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
@@ -122,11 +122,8 @@ const styles = (theme: SaladTheme) => ({
 export interface AntivirusGuideProps extends WithStyles<typeof styles> {
   isNative: boolean
   antivirusName?: string
-  article?: string
-  loading?: boolean
   loadArticle?: () => void
   onCloseClicked?: () => void
-  antiVirusGuideVideoId?: number
   navigateToAVGuide: (antivirusSoftwareName: AntiVirusSoftware, label: string) => void
   onNoAVClick: () => void
   articleId?: number

--- a/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
+++ b/packages/web-app/src/modules/onboarding-views/pages/AntivirusGuide.tsx
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, Modal, Text } from '@saladtechnologies/garden-components'
 import { Component } from 'react'
 import withStyles, { WithStyles } from 'react-jss'
-import Skeleton from 'react-loading-skeleton'
 import { ModalPage } from '../../../components'
 import { SaladTheme } from '../../../SaladTheme'
 import { AntiVirusSoftware } from '../../zendesk/models'
@@ -88,6 +87,8 @@ const styles = (theme: SaladTheme) => ({
     lineHeight: '150%',
   },
   subtitle: {
+    marginTop: 16,
+    marginBottom: 8,
     fontSize: theme.medium,
   },
   '@keyframes fadeIn': {
@@ -129,6 +130,7 @@ export interface AntivirusGuideProps extends WithStyles<typeof styles> {
   navigateToAVGuide: (antivirusSoftwareName: AntiVirusSoftware, label: string) => void
   onNoAVClick: () => void
   articleId?: number
+  helpScoutUrl?: string
 }
 
 interface State {
@@ -198,17 +200,8 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
   }
 
   render() {
-    const {
-      antivirusName,
-      article,
-      loading,
-      onCloseClicked,
-      antiVirusGuideVideoId,
-      isNative,
-      navigateToAVGuide,
-      onNoAVClick,
-      classes,
-    } = this.props
+    const { antivirusName, onCloseClicked, isNative, navigateToAVGuide, onNoAVClick, classes, helpScoutUrl } =
+      this.props
 
     const { webWidgetShowing, showAVSelectionModal } = this.state
 
@@ -220,48 +213,25 @@ class _AntivirusGuide extends Component<AntivirusGuideProps, State> {
         <OnboardingAntiVirusScrollbar>
           <div className={classes.page}>
             <div className={classes.container}>
-              {loading ? (
-                <Skeleton height={'100%'} />
-              ) : (
-                <>
-                  <div className={classes.heading}>
-                    <div className={classes.title}>
-                      <Text variant="headline">{antivirusName}</Text>
-                    </div>
-                    <div className={classes.subtitle}>
-                      <Text variant="baseS">
-                        Use a different anti-virus provider?{' '}
-                        <span className={classes.link} onClick={this.handleOpenAVSelectionModal}>
-                          Select it from this list
-                        </span>
-                        .
-                      </Text>
-                    </div>
-                  </div>
-                  {article ? (
-                    <>
-                      {antiVirusGuideVideoId && (
-                        <div className={classes.video}>
-                          <iframe
-                            title={antivirusName}
-                            src={`//player.vimeo.com/video/${antiVirusGuideVideoId}`}
-                            width="640"
-                            height="360"
-                            frameBorder="0"
-                            allowFullScreen
-                          ></iframe>
-                        </div>
-                      )}
-                      <Text variant="baseL">
-                        <div className={classes.content} dangerouslySetInnerHTML={{ __html: article }} />{' '}
-                      </Text>
-                    </>
-                  ) : null}
-                  <span className={classes.closeButtonContainer}>
-                    <Button size="medium" label="Close" onClick={onCloseClicked} />
+              <div className={classes.heading}>
+                <div className={classes.title}>
+                  <Text variant="headline">{antivirusName}</Text>
+                </div>
+              </div>
+
+              <iframe width={700} height={700} title={antivirusName} src={helpScoutUrl} />
+              <div className={classes.subtitle}>
+                <Text variant="baseS">
+                  Use a different anti-virus provider?{' '}
+                  <span className={classes.link} onClick={this.handleOpenAVSelectionModal}>
+                    Select it from this list
                   </span>
-                </>
-              )}
+                  .
+                </Text>
+              </div>
+              <span className={classes.closeButtonContainer}>
+                <Button size="medium" label="Close" onClick={onCloseClicked} />
+              </span>
             </div>
           </div>
         </OnboardingAntiVirusScrollbar>

--- a/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
@@ -18,9 +18,6 @@ export class OnboardingAntivirusStore {
   @observable
   public helpCenterArticle?: string
 
-  @observable
-  public loadingArticle: boolean = false
-
   constructor(private readonly store: RootStore) {}
 
   /**
@@ -139,7 +136,6 @@ export class OnboardingAntivirusStore {
 
   @action.bound
   loadArticle = function (this: OnboardingAntivirusStore, articleID: number) {
-    this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
     this.store.zendesk.helpScoutUrl = getZendeskAVData(articleID).helpScoutUrl
     this.selectedAntiVirusGuide = getZendeskAVData(articleID).name
   }.bind(this)

--- a/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
+++ b/packages/web-app/src/modules/onboarding/OnboardingAntivirusStore.tsx
@@ -1,7 +1,6 @@
 import { action, flow, observable } from 'mobx'
 import { RootStore } from '../../Store'
 import { delay, routeLink } from '../../utils'
-import type { ZendeskArticleResource } from '../zendesk/models'
 import { AntiVirusSoftware } from '../zendesk/models'
 import { getZendeskAVData } from '../zendesk/utils'
 import { ONBOARDING_PAGE_NAMES, WhitelistWindowsDefenderErrorTypeMessage } from './models'
@@ -139,26 +138,9 @@ export class OnboardingAntivirusStore {
   }
 
   @action.bound
-  loadArticle = flow(
-    function* (this: OnboardingAntivirusStore, articleID: number) {
-      const antivirusSoftwareName = getZendeskAVData(articleID).name
-      this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
-      if (antivirusSoftwareName === this.selectedAntiVirusGuide && this.helpCenterArticle !== undefined) {
-        return
-      }
-
-      this.loadingArticle = true
-      try {
-        let res: Response = yield fetch(`https://salad.zendesk.com/api/v2/help_center/en-us/articles/${articleID}`, {
-          credentials: 'omit',
-        })
-        const data: ZendeskArticleResource = yield res.json()
-        this.helpCenterArticle = data.article.body
-        this.selectedAntiVirusGuide = antivirusSoftwareName
-      } catch (err) {
-        throw err
-      }
-      this.loadingArticle = false
-    }.bind(this),
-  )
+  loadArticle = function (this: OnboardingAntivirusStore, articleID: number) {
+    this.store.zendesk.antiVirusGuideVideoId = getZendeskAVData(articleID).videoId
+    this.store.zendesk.helpScoutUrl = getZendeskAVData(articleID).helpScoutUrl
+    this.selectedAntiVirusGuide = getZendeskAVData(articleID).name
+  }.bind(this)
 }

--- a/packages/web-app/src/modules/zendesk/Zendesk.ts
+++ b/packages/web-app/src/modules/zendesk/Zendesk.ts
@@ -40,9 +40,6 @@ export class Zendesk {
   @observable
   public errorType: ErrorPageType = ErrorPageType.Unknown
 
-  @observable
-  public antiVirusGuideVideoId?: number
-
   @observable helpScoutUrl?: string
 
   @observable helpScoutFirewallArticle?: string

--- a/packages/web-app/src/modules/zendesk/Zendesk.ts
+++ b/packages/web-app/src/modules/zendesk/Zendesk.ts
@@ -7,8 +7,8 @@ import { ErrorPageType } from '../../UIStore'
 import type { AnalyticsStore } from '../analytics'
 import type { AuthStore } from '../auth'
 import type { NativeStore } from '../machine'
-import type { AntiVirusSoftware, ZendeskArticle } from './models'
-import { getAntiVirusSoftware, getZendeskAVData } from './utils'
+import type { AntiVirusSoftware } from './models'
+import { antivirusInfo, getAntiVirusSoftware, getZendeskAVData } from './utils'
 
 const defaultBeaconId = '29fdaae4-715f-48dc-b93e-5552ef031abc'
 
@@ -35,7 +35,7 @@ export class Zendesk {
   public loadingArticle: boolean = false
 
   @observable
-  public antiVirusArticleList?: ZendeskArticle[]
+  public antiVirusArticleList?: typeof antivirusInfo
 
   @observable
   public errorType: ErrorPageType = ErrorPageType.Unknown
@@ -46,8 +46,6 @@ export class Zendesk {
   @observable helpScoutUrl?: string
 
   @observable helpScoutFirewallArticle?: string
-
-  @observable helpScoutAntiVirusList?: string
 
   private readonly useZendesk: boolean
 
@@ -423,12 +421,14 @@ export class Zendesk {
   @action.bound
   loadAntiVirusArticleList = function (this: Zendesk) {
     this.setErrorType(ErrorPageType.AntiVirus)
-    this.helpScoutAntiVirusList = `https://support.salad.com/category/30-anti-virus`
+    this.antiVirusArticleList = antivirusInfo
+    this.analytics.trackErrorPageViewed('Generic Anti-Virus Error')
   }.bind(this)
 
   @action.bound
   loadFirewallArticle = function (this: Zendesk) {
     this.setErrorType(ErrorPageType.Firewall)
+    this.analytics.trackErrorPageViewed('Firewall Error')
     this.helpScoutFirewallArticle = `https://support.salad.com/article/219-whitelisting-salad-in-your-firewall`
   }.bind(this)
 }

--- a/packages/web-app/src/modules/zendesk/utils.ts
+++ b/packages/web-app/src/modules/zendesk/utils.ts
@@ -37,6 +37,7 @@ interface ZendeskAVData {
   id?: number
   name?: AntiVirusSoftware
   videoId?: number
+  helpScoutUrl?: string
 }
 
 export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number): ZendeskAVData => {
@@ -46,155 +47,185 @@ export const getZendeskAVData = (identifier: AntiVirusSoftware | string | number
     case AntiVirusSoftware.Adaware:
     case 360041688612:
       zendeskAVData.id = 360041688612
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/148-how-to-whitelist-salad-in-adaware`
       zendeskAVData.name = AntiVirusSoftware.Adaware
       break
     case AntiVirusSoftware.AdvancedSystemCareUltimate:
     case 360042137651:
       zendeskAVData.id = 360042137651
       zendeskAVData.name = AntiVirusSoftware.AdvancedSystemCareUltimate
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/149-how-to-whitelist-salad-in-advanced-systemcare-ultimate`
       break
     case AntiVirusSoftware.Avast:
     case 360033487211:
       zendeskAVData.id = 360033487211
       zendeskAVData.name = AntiVirusSoftware.Avast
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/144-how-to-whitelist-salad-in-avast-antivirus`
       zendeskAVData.videoId = 574387141
       break
     case AntiVirusSoftware.AVG:
     case 360041706612:
       zendeskAVData.id = 360041706612
       zendeskAVData.name = AntiVirusSoftware.AVG
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/150-how-to-whitelist-salad-in-avg`
       break
     case AntiVirusSoftware.Avira:
     case 360042139651:
       zendeskAVData.id = 360042139651
       zendeskAVData.name = AntiVirusSoftware.Avira
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/151-how-to-whitelist-salad-in-avira`
       break
     case AntiVirusSoftware.BitDefender:
     case 360033488151:
       zendeskAVData.id = 360033488151
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/145-how-to-whitelist-salad-in-bitdefender-antivirus-plus`
       zendeskAVData.name = AntiVirusSoftware.BitDefender
       break
     case AntiVirusSoftware.BullGuard:
     case 360041708232:
       zendeskAVData.id = 360041708232
       zendeskAVData.name = AntiVirusSoftware.BullGuard
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/152-how-to-whitelist-salad-in-bullguard`
       break
     case AntiVirusSoftware.Comodo:
     case 360041713452:
       zendeskAVData.id = 360041713452
       zendeskAVData.name = AntiVirusSoftware.Comodo
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/153-how-to-whitelist-salad-in-comodo`
       break
     case AntiVirusSoftware.EScan:
     case 360041720452:
       zendeskAVData.id = 360041720452
       zendeskAVData.name = AntiVirusSoftware.EScan
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/154-how-to-whitelist-salad-in-e-scan`
       break
     case AntiVirusSoftware.ESETNOD32:
     case 360041721632:
       zendeskAVData.id = 360041721632
       zendeskAVData.name = AntiVirusSoftware.ESETNOD32
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/155-how-to-whitelist-salad-in-eset-nod32`
       break
     case AntiVirusSoftware.FProt:
     case 360042153731:
       zendeskAVData.id = 360042153731
       zendeskAVData.name = AntiVirusSoftware.FProt
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/156-how-to-whitelist-salad-in-f-prot`
       break
     case AntiVirusSoftware.FSecure:
     case 360042154431:
       zendeskAVData.id = 360042154431
       zendeskAVData.name = AntiVirusSoftware.FSecure
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/157-how-to-whitelist-salad-in-f-secure`
       break
     case AntiVirusSoftware.GData:
     case 360042154771:
       zendeskAVData.id = 360042154771
       zendeskAVData.name = AntiVirusSoftware.GData
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/158-how-to-whitelist-salad-in-gdata`
       break
     case AntiVirusSoftware.K7:
     case 360041736392:
       zendeskAVData.id = 360041736392
       zendeskAVData.name = AntiVirusSoftware.K7
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/159-how-to-whitelist-salad-in-k7`
       break
     case AntiVirusSoftware.Kaspersky:
     case 360042167171:
       zendeskAVData.id = 360042167171
       zendeskAVData.name = AntiVirusSoftware.Kaspersky
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/160-how-to-whitelist-salad-in-kaspersky`
       break
     case AntiVirusSoftware.Malwarebytes:
     case 360031870772:
       zendeskAVData.id = 360031870772
       zendeskAVData.name = AntiVirusSoftware.Malwarebytes
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/141-how-to-whitelist-salad-in-malwarebytes`
       break
     case AntiVirusSoftware.McAfeeSecurity:
     case 360033488271:
       zendeskAVData.id = 360033488271
       zendeskAVData.name = AntiVirusSoftware.McAfeeSecurity
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/146-how-to-whitelist-salad-in-mcafee`
       zendeskAVData.videoId = 575421455
       break
     case AntiVirusSoftware.Norton:
     case 360032211151:
       zendeskAVData.id = 360032211151
       zendeskAVData.name = AntiVirusSoftware.Norton
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/142-how-to-whitelist-salad-in-norton-antivirus`
       break
     case AntiVirusSoftware.Panda:
     case 360033488451:
       zendeskAVData.id = 360033488451
       zendeskAVData.name = AntiVirusSoftware.Panda
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/147-how-to-whitelist-salad-in-panda`
       break
     case AntiVirusSoftware.PCMatic:
     case 360042169891:
       zendeskAVData.id = 360042169891
       zendeskAVData.name = AntiVirusSoftware.PCMatic
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/161-how-to-whitelist-salad-in-pcmatic`
       break
     case AntiVirusSoftware.Qihoo360:
     case 360042222471:
       zendeskAVData.id = 360042222471
       zendeskAVData.name = AntiVirusSoftware.Qihoo360
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/162-how-to-whitelist-salad-in-qihoo-360`
       break
     case AntiVirusSoftware.SecureAgeAPEX:
     case 360041801812:
       zendeskAVData.id = 360041801812
       zendeskAVData.name = AntiVirusSoftware.SecureAgeAPEX
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/163-how-to-whitelist-salad-in-secureage-apex`
       break
     case AntiVirusSoftware.Sophos:
     case 360041802092:
       zendeskAVData.id = 360041802092
       zendeskAVData.name = AntiVirusSoftware.Sophos
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/164-how-to-whitelist-salad-in-sophos`
       break
     case AntiVirusSoftware.TotalAV:
     case 360041802372:
       zendeskAVData.id = 360041802372
       zendeskAVData.name = AntiVirusSoftware.TotalAV
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/165-how-to-whitelist-salad-in-totalav`
       break
     case AntiVirusSoftware.TrendMicro:
     case 360042223291:
       zendeskAVData.id = 360042223291
       zendeskAVData.name = AntiVirusSoftware.TrendMicro
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/166-how-to-whitelist-salad-in-trendmicro`
       break
     case AntiVirusSoftware.Twister:
     case 360042223891:
       zendeskAVData.id = 360042223891
       zendeskAVData.name = AntiVirusSoftware.Twister
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/167-how-to-whitelist-salad-in-twister`
       break
     case AntiVirusSoftware.VIPRE:
     case 360041803732:
       zendeskAVData.id = 360041803732
       zendeskAVData.name = AntiVirusSoftware.VIPRE
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/168-how-to-whitelist-salad-in-vipre`
       break
     case AntiVirusSoftware.Webroot:
     case 360041804212:
       zendeskAVData.id = 360041804212
       zendeskAVData.name = AntiVirusSoftware.Webroot
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/169-how-to-whitelist-salad-in-webroot`
       break
     case AntiVirusSoftware.WindowsDefender:
     case 360033124692:
       zendeskAVData.id = 360033124692
       zendeskAVData.name = AntiVirusSoftware.WindowsDefender
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/143-how-to-whitelist-salad-in-windows-defender`
       zendeskAVData.videoId = 574423693
       break
     case AntiVirusSoftware.Zillya:
     case 360042225091:
       zendeskAVData.id = 360042225091
       zendeskAVData.name = AntiVirusSoftware.Zillya
+      zendeskAVData.helpScoutUrl = `https://support.salad.com/article/170-how-to-whitelist-salad-in-zillya`
       break
   }
 


### PR DESCRIPTION
the onboarding pages will be the same but in our alpha branch, we are using the `error/` routes. of the error routes, only the three below were pulling from zendesk

**- `/errors/anti-virus/:id`**
![image](https://user-images.githubusercontent.com/37646831/158480726-a82fecab-e915-4541-85ae-fa74701b6857.png)
![image](https://user-images.githubusercontent.com/37646831/158480821-1b3b95b2-393e-4e85-aa2a-0d01546067b1.png)
clicking the link will bring us to the generic antivirus route.
![av gif2](https://user-images.githubusercontent.com/37646831/158480994-b5f08db3-e699-49c6-a005-dfd353e9ea7e.gif)


**- `/errors/anti-virus/`** 
![image](https://user-images.githubusercontent.com/37646831/158480631-7d357120-3ab9-471c-8656-989f7cbec2c3.png)

**- `/errors/firewall`**
![image](https://user-images.githubusercontent.com/37646831/158481089-41499b7d-a51a-411d-88ea-0983b1ab8ce6.png)
