### PR TITLE
Updates miner profitability order to ETC first

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
@@ -10,8 +10,8 @@ import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createWindowsPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
   ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createXMRigKawPowPluginDefinitions(accounts),
   ...createPhoenixMinerEtchashPluginDefinitions(accounts),
+  ...createXMRigKawPowPluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
   ...createGMinerCuckooCyclePluginDefinitions(accounts),


### PR DESCRIPTION
ETC mining profitability has just shot up above KawPow. This shifts the priority to running ETCHASH over KawPow.

Please also merge, thanks.