### PR TITLE
Changes profitability order to KawPow above ETC

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
@@ -10,8 +10,8 @@ import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createWindowsPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
   ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createPhoenixMinerEtchashPluginDefinitions(accounts),
   ...createXMRigKawPowPluginDefinitions(accounts),
+  ...createPhoenixMinerEtchashPluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
   ...createGMinerCuckooCyclePluginDefinitions(accounts),


### PR DESCRIPTION
KawPow has now overtaken ETC as more profitable for 4GB VRAM GPUs, this PR changes the order of algorithms again. Please also merge, thanks.