### PR TITLE
Revert "Changes profitability order to KawPow above ETC"

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
@@ -10,8 +10,8 @@ import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createWindowsPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
   ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createXMRigKawPowPluginDefinitions(accounts),
   ...createPhoenixMinerEtchashPluginDefinitions(accounts),
+  ...createXMRigKawPowPluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
   ...createGMinerCuckooCyclePluginDefinitions(accounts),


### PR DESCRIPTION
Reverts SaladTechnologies/salad-applications#917

Looks like the KawPow DAG file is too large for some systems due to Windows pre-allocating too much VRAM to itself, preventing the (only 3.3GB) DAG from being able to fit for some 4GB GPU users. 