### PR TITLE
[SaladCard] Adds SaladCard enroll page

### DIFF
--- a/packages/web-app/src/Routes.tsx
+++ b/packages/web-app/src/Routes.tsx
@@ -19,6 +19,7 @@ import {
   SleepModeConfigurationPageContainer,
 } from './modules/onboarding-views'
 import { RewardDetailsContainer } from './modules/reward-views'
+import { SaladCardEnrollmentPageContainer } from './modules/salad-card-views/SaladCardEnrollmentPageContainer'
 import { SaladPayOrderSummaryContainer } from './modules/salad-pay-views'
 import { SettingsContainer } from './modules/settings-views'
 import { StorefrontHomePage } from './modules/storefront-views/pages/StorefrontHomePage'
@@ -93,6 +94,7 @@ const _Routes = ({ location }: RouteComponentProps) => {
       {saladBowlEnabled && <Redirect exact from="/settings/desktop-settings" to="/earn/machine-settings" />}
 
       <Redirect exact from="/earn" to="/earn/summary" />
+      <Route path="/earn/saladcard" component={SaladCardEnrollmentPageContainer} />
       {saladBowlEnabled ? (
         <Route path="/earn/mining" component={EarningsSummaryPageContainer} />
       ) : (

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -27,6 +27,7 @@ import { SaladBowlStore } from './modules/salad-bowl'
 import { StopReason } from './modules/salad-bowl/models'
 import { SaladBowlStoreInterface } from './modules/salad-bowl/SaladBowlStoreInterface'
 import { SaladForkAndBowlStore } from './modules/salad-bowl/SaladForkAndBowlStore'
+import { SaladCardStore } from './modules/salad-card/SaladCardStore'
 import { SeasonsStore } from './modules/seasons'
 import { StartButtonUIStore } from './modules/start-button/StartButtonUIStore'
 import { StorefrontStore } from './modules/storefront/StorefrontStore'
@@ -91,6 +92,7 @@ export class RootStore {
   public readonly machineSettingsUI: MachineSettingsUIStore
   public readonly detectedHardwareUIStore: DetectedHardwareUIStore
   public readonly activeWorkloadsUIStore: ActiveWorkloadsUIStore
+  public readonly saladCard: SaladCardStore
 
   constructor(axios: AxiosInstance, private readonly featureManager: FeatureManager) {
     this.routing = new RouterStore()
@@ -130,6 +132,7 @@ export class RootStore {
     this.machineSettingsUI = new MachineSettingsUIStore(this)
     this.detectedHardwareUIStore = new DetectedHardwareUIStore(this)
     this.activeWorkloadsUIStore = new ActiveWorkloadsUIStore(this)
+    this.saladCard = new SaladCardStore(this, axios)
 
     // Start refreshing data
     this.refresh.start()

--- a/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
+++ b/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
@@ -3,7 +3,7 @@ import { RootStore } from '../../Store'
 import { SaladCardEnrollmentPage } from './pages/SaladCardEnrollmentPage'
 
 const mapStoreToProps = (store: RootStore): any => ({
-  handleCreateSaladCard: store.saladCard.CreateSaladCard,
+  handleCreateSaladCard: store.saladCard.createSaladCard,
   isAcceptedTerms: store.saladCard.isAcceptedTerms,
   onToggleAccept: store.saladCard.toggleAcceptTerms,
   isSubmitting: store.saladCard.isSubmitting,

--- a/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
+++ b/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
@@ -4,7 +4,7 @@ import { SaladCardEnrollmentPage } from './pages/SaladCardEnrollmentPage'
 
 const mapStoreToProps = (store: RootStore): any => ({
   handleCreateSaladCard: store.saladCard.createSaladCard,
-  isAcceptedTerms: store.saladCard.isAcceptedTerms,
+  hasAcceptedTerms: store.saladCard.hasAcceptedTerms,
   onToggleAccept: store.saladCard.toggleAcceptTerms,
   isSubmitting: store.saladCard.isSubmitting,
   hasSaladCard: store.saladCard.hasSaladCard,

--- a/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
+++ b/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
@@ -1,0 +1,15 @@
+import { connect } from '../../connect'
+import { RootStore } from '../../Store'
+import { SaladCardEnrollmentPage } from './pages/SaladCardEnrollmentPage'
+
+const mapStoreToProps = (store: RootStore): any => ({
+  handleCreateSaladCard: store.saladCard.CreateSaladCard,
+  isAcceptedTerms: store.saladCard.isAcceptedTerms,
+  onToggleAccept: store.saladCard.toggleAcceptTerms,
+  isSubmitting: store.saladCard.isSubmitting,
+  hasSaladCard: store.saladCard.hasSaladCard,
+  handleRouteToStore: store.saladCard.routeToStore,
+  handleCheckForSaladCard: store.saladCard.checkForSaladCard,
+})
+
+export const SaladCardEnrollmentPageContainer = connect(mapStoreToProps, SaladCardEnrollmentPage)

--- a/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
+++ b/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
@@ -1,0 +1,125 @@
+import { Button, Checkbox, Layout, Text } from '@saladtechnologies/garden-components'
+import { useEffect } from 'react'
+import Scrollbars from 'react-custom-scrollbars'
+import withStyles, { WithStyles } from 'react-jss'
+import { Head } from '../../../components'
+import { SaladTheme } from '../../../SaladTheme'
+import { withLogin } from '../../auth-views'
+
+const styles = (theme: SaladTheme) => ({
+  page: {
+    backgroundImage: 'linear-gradient(to right, #56A431 , #AACF40)',
+    color: theme.darkBlue,
+    flex: 1,
+  },
+  parentContainer: {
+    width: 688,
+  },
+  mb48: {
+    marginBottom: 48,
+  },
+  link: {
+    color: theme.darkBlue,
+    cursor: 'pointer',
+  },
+})
+
+interface SaladCardEnrollmentPageProps extends WithStyles<typeof styles> {
+  handleCreateSaladCard: () => void
+  isAcceptedTerms: boolean
+  onToggleAccept: (accepted: boolean) => void
+  isSubmitting: boolean
+  hasSaladCard: boolean
+  handleRouteToStore: () => void
+  handleCheckForSaladCard: () => void
+}
+
+const _SaladCardEnrollmentPage = ({
+  classes,
+  handleCreateSaladCard,
+  isAcceptedTerms,
+  onToggleAccept,
+  isSubmitting,
+  hasSaladCard,
+  handleRouteToStore,
+  handleCheckForSaladCard,
+}: SaladCardEnrollmentPageProps) => {
+  useEffect(() => {
+    handleCheckForSaladCard()
+    hasSaladCard && handleRouteToStore()
+  }, [handleCheckForSaladCard, handleRouteToStore, hasSaladCard])
+  return (
+    <div className={classes.page}>
+      <Scrollbars>
+        <Layout title="SaladCard">
+          <Head title="SaladCard" />
+          <div className={classes.parentContainer}>
+            <div className={classes.mb48}>
+              <Text variant="baseL">SaladCard is the easiest way to spend your balance on your favorite sites</Text>
+            </div>
+            <div className={classes.mb48}>
+              <Text variant="baseXL">What is SaladCard?</Text>
+            </div>
+            <div className={classes.mb48}>
+              <Text variant="baseL">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua.{' '}
+              </Text>
+            </div>
+            <div className={classes.mb48}>
+              <Text variant="baseXL">How does it work? </Text>
+            </div>
+            <div className={classes.mb48}>
+              <Text variant="baseL">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua.{' '}
+              </Text>
+            </div>
+            <div className={classes.mb48}>
+              <Checkbox onChange={onToggleAccept} checked={isAcceptedTerms}>
+                <Text variant="baseM">
+                  I agree to the SaladCard{' '}
+                  <a
+                    className={classes.link}
+                    href="https://salad.com/terms-and-conditions"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Terms of Service,
+                  </a>{' '}
+                  <a
+                    className={classes.link}
+                    href="https://salad.com/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Cardholder Policy,
+                  </a>
+                  {' and '}
+                  <a
+                    className={classes.link}
+                    href="https://salad.com/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Privacy Policy
+                  </a>
+                </Text>
+              </Checkbox>
+            </div>
+            <div className={classes.mb48}>
+              <Button
+                onClick={handleCreateSaladCard}
+                disabled={!isAcceptedTerms}
+                isLoading={isSubmitting}
+                label="Get SaladCard"
+              />
+            </div>
+          </div>
+        </Layout>
+      </Scrollbars>
+    </div>
+  )
+}
+
+export const SaladCardEnrollmentPage = withLogin(withStyles(styles)(_SaladCardEnrollmentPage))

--- a/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
+++ b/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
@@ -26,7 +26,7 @@ const styles = (theme: SaladTheme) => ({
 
 interface SaladCardEnrollmentPageProps extends WithStyles<typeof styles> {
   handleCreateSaladCard: () => void
-  isAcceptedTerms: boolean
+  hasAcceptedTerms: boolean
   onToggleAccept: (accepted: boolean) => void
   isSubmitting: boolean
   hasSaladCard: boolean
@@ -37,7 +37,7 @@ interface SaladCardEnrollmentPageProps extends WithStyles<typeof styles> {
 const _SaladCardEnrollmentPage = ({
   classes,
   handleCreateSaladCard,
-  isAcceptedTerms,
+  hasAcceptedTerms,
   onToggleAccept,
   isSubmitting,
   hasSaladCard,
@@ -76,7 +76,7 @@ const _SaladCardEnrollmentPage = ({
               </Text>
             </div>
             <div className={classes.mb48}>
-              <Checkbox onChange={onToggleAccept} checked={isAcceptedTerms}>
+              <Checkbox onChange={onToggleAccept} checked={hasAcceptedTerms}>
                 <Text variant="baseM">
                   I agree to the SaladCard{' '}
                   <a
@@ -110,7 +110,7 @@ const _SaladCardEnrollmentPage = ({
             <div className={classes.mb48}>
               <Button
                 onClick={handleCreateSaladCard}
-                disabled={!isAcceptedTerms}
+                disabled={!hasAcceptedTerms}
                 isLoading={isSubmitting}
                 label="Get SaladCard"
               />

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -25,7 +25,7 @@ export class SaladCardStore {
   }
 
   @action.bound
-  public CreateSaladCard = flow(function* (this: SaladCardStore) {
+  public createSaladCard = flow(function* (this: SaladCardStore) {
     this.isSubmitSuccess = false
     try {
       this.isSubmitting = true

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -49,7 +49,7 @@ export class SaladCardStore {
       const saladCardData = response.data
       if (saladCardData.length > 0) {
         this.hasSaladCard = true
-      } else if (saladCardData.length === 0) {
+      } else {
         this.hasSaladCard = false
       }
     } catch (e) {

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -1,0 +1,59 @@
+import Axios, { AxiosInstance } from 'axios'
+import { action, flow, observable } from 'mobx'
+import { RootStore } from '../../Store'
+
+export class SaladCardStore {
+  @observable
+  public isAcceptedTerms: boolean = false
+
+  @observable
+  public isSubmitting: boolean = false
+
+  @observable
+  public isSubmitSuccess: boolean = false
+
+  @observable hasSaladCard: boolean = false
+
+  @action
+  public toggleAcceptTerms = (accepted: boolean) => {
+    this.isAcceptedTerms = accepted
+  }
+
+  @action
+  public routeToStore = () => {
+    this.store.routing.push('/store')
+  }
+
+  @action.bound
+  public CreateSaladCard = flow(function* (this: SaladCardStore) {
+    this.isSubmitSuccess = false
+    try {
+      this.isSubmitting = true
+      yield this.axios.post('/api/v2/salad-card/cards')
+      this.isSubmitSuccess = true
+      this.hasSaladCard = true
+    } catch (e) {
+      this.isSubmitSuccess = false
+      if (Axios.isAxiosError(e)) {
+        throw e
+      }
+    } finally {
+      this.isSubmitting = false
+    }
+  })
+
+  @action.bound
+  public checkForSaladCard = flow(function* (this: SaladCardStore) {
+    try {
+      const response = yield this.axios.get('/api/v2/salad-card/cards')
+      const saladCardData = response.data
+      if (saladCardData.length > 0) {
+        this.hasSaladCard = true
+      }
+    } catch (e) {
+      this.hasSaladCard = false
+    }
+  })
+
+  constructor(private readonly store: RootStore, private readonly axios: AxiosInstance) {}
+}

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -49,6 +49,8 @@ export class SaladCardStore {
       const saladCardData = response.data
       if (saladCardData.length > 0) {
         this.hasSaladCard = true
+      } else if (saladCardData.length === 0) {
+        this.hasSaladCard = false
       }
     } catch (e) {
       this.hasSaladCard = false

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -4,7 +4,7 @@ import { RootStore } from '../../Store'
 
 export class SaladCardStore {
   @observable
-  public isAcceptedTerms: boolean = false
+  public hasAcceptedTerms: boolean = false
 
   @observable
   public isSubmitting: boolean = false
@@ -16,7 +16,7 @@ export class SaladCardStore {
 
   @action
   public toggleAcceptTerms = (accepted: boolean) => {
-    this.isAcceptedTerms = accepted
+    this.hasAcceptedTerms = accepted
   }
 
   @action


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37646831/168304626-79360c8c-5c86-4e37-9969-3f096fbe210c.png)

Copy and designs haven't been finalized but we wanted to get at least this place holder page in. 
- The `Get SaladCard` button isn't clickable until you agree to the terms and service. 
- After clicking the button, we make a post call to the SaladCard api Dima and Joe built which creates a card. After the card is successfully created, we push the users to the store. 
- When users first visit the `earn/saladcard` page, we run a check to see if they have a saladcard and if they do, we push them to the store. 