### PR TITLE
[SaladCard] make sure user is enrolled in SaladCard before redeeming SaladCard rewards

### DIFF
--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -110,7 +110,8 @@ export class RootStore {
 
     this.machine = new MachineStore(this, axios, featureManager)
     this.profile = new ProfileStore(this, axios)
-    this.rewards = new RewardStore(this, axios, this.profile)
+    this.saladCard = new SaladCardStore(this, axios)
+    this.rewards = new RewardStore(this, axios, this.profile, this.saladCard)
     this.analytics = new AnalyticsStore(this)
     this.balance = new BalanceStore(axios)
     this.ui = new UIStore(this)
@@ -132,7 +133,6 @@ export class RootStore {
     this.machineSettingsUI = new MachineSettingsUIStore(this)
     this.detectedHardwareUIStore = new DetectedHardwareUIStore(this)
     this.activeWorkloadsUIStore = new ActiveWorkloadsUIStore(this)
-    this.saladCard = new SaladCardStore(this, axios)
 
     // Start refreshing data
     this.refresh.start()
@@ -187,6 +187,7 @@ export class RootStore {
         this.referral.loadReferralCode(),
         this.refresh.refreshData(),
         this.profile.loadPayPalId(),
+        this.saladCard.loadSaladCard(),
         this.zendesk.login(profile.username, profile.email),
         Promise.race([this.saladBowl.login(), delay(10000)]),
       ])

--- a/packages/web-app/src/modules/reward-views/RewardDetailsContainer.tsx
+++ b/packages/web-app/src/modules/reward-views/RewardDetailsContainer.tsx
@@ -16,10 +16,13 @@ const mapStoreToProps = (store: RootStore, props: RouteComponentProps<{ id: stri
 
   const extensions = store.profile.currentProfile?.extensions
   const hasPayPalAccount = store.profile.payPalId != null
+  const hasSaladCard = store.saladCard.hasSaladCard === true
   const reward = store.rewards.getReward(props.match.params.id)
   const requiresMinecraftUsername =
     reward?.tags?.includes('requires-minecraft-username') && !extensions?.minecraftUsername
   const requiresPayPalAccount = reward?.tags?.includes('requires-paypal-account') && !hasPayPalAccount
+  const requiresSaladCard = reward?.tags?.includes('requires-saladcard-account') && !hasSaladCard
+
   return {
     loadReward: store.rewards.loadAndTrackReward,
     authenticated: store.auth.isAuthenticated,
@@ -33,6 +36,7 @@ const mapStoreToProps = (store: RootStore, props: RouteComponentProps<{ id: stri
     onRemoveFromCart: store.rewards.removeFromChoppingCart,
     requiresMinecraftUsername: requiresMinecraftUsername,
     requiresPayPalAccount,
+    requiresSaladCard,
     trackDisabledBuyNowClick,
   }
 }

--- a/packages/web-app/src/modules/reward-views/components/RewardComponents.stories.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardComponents.stories.tsx
@@ -231,6 +231,7 @@ storiesOf('Modules/Rewards/Reward Header Bar', module)
         onRedeem={action('redeem')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )
@@ -244,6 +245,7 @@ storiesOf('Modules/Rewards/Reward Header Bar', module)
         onRedeem={action('redeem')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )
@@ -258,6 +260,7 @@ storiesOf('Modules/Rewards/Reward Header Bar', module)
         onRedeem={action('redeem')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )
@@ -272,6 +275,7 @@ storiesOf('Modules/Rewards/Reward Header Bar', module)
         onRedeem={action('redeem')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )
@@ -286,6 +290,7 @@ storiesOf('Modules/Rewards/Reward Header Bar', module)
         onRedeem={action('redeem')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )

--- a/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
@@ -96,6 +96,7 @@ interface Props extends WithStyles<typeof styles> {
   onRemoveFromCart?: (reward: Reward) => void
   requiresMinecraftUsername: boolean
   requiresPayPalAccount: boolean
+  requiresSaladCard: boolean
   trackDisabledBuyNowClick: () => void
 }
 
@@ -122,6 +123,7 @@ class _RewardHeaderBar extends Component<Props> {
       currentBalance,
       requiresMinecraftUsername,
       requiresPayPalAccount,
+      requiresSaladCard,
       trackDisabledBuyNowClick,
       classes,
     } = this.props
@@ -182,6 +184,11 @@ class _RewardHeaderBar extends Component<Props> {
               {requiresPayPalAccount && authenticated && (
                 <div className={classnames(classes.priceText, classes.stockLabel, classes.insufficientBalanceLabel)}>
                   <SmartLink to="/account/summary">Add PayPal account</SmartLink>
+                </div>
+              )}
+              {requiresSaladCard && authenticated && (
+                <div className={classnames(classes.priceText, classes.stockLabel, classes.insufficientBalanceLabel)}>
+                  <SmartLink to="/earn/saladcard">Enroll in SaladCard</SmartLink>
                 </div>
               )}
             </div>

--- a/packages/web-app/src/modules/reward-views/pages/RewardDetailsPage.tsx
+++ b/packages/web-app/src/modules/reward-views/pages/RewardDetailsPage.tsx
@@ -42,6 +42,7 @@ interface Props extends WithStyles<typeof styles> {
   requiresMinecraftUsername: boolean
   trackDisabledBuyNowClick: () => void
   requiresPayPalAccount: boolean
+  requiresSaladCard: boolean
 }
 
 class _RewardDetailsPage extends Component<Props> {
@@ -57,6 +58,7 @@ class _RewardDetailsPage extends Component<Props> {
       onBack,
       requiresMinecraftUsername,
       requiresPayPalAccount,
+      requiresSaladCard,
       trackDisabledBuyNowClick,
       classes,
       ...rest
@@ -70,6 +72,7 @@ class _RewardDetailsPage extends Component<Props> {
           onRedeem={onRedeem}
           requiresMinecraftUsername={requiresMinecraftUsername}
           requiresPayPalAccount={requiresPayPalAccount}
+          requiresSaladCard={true}
           trackDisabledBuyNowClick={trackDisabledBuyNowClick}
           {...rest}
         />

--- a/packages/web-app/src/modules/reward-views/pages/RewardPages.stories.tsx
+++ b/packages/web-app/src/modules/reward-views/pages/RewardPages.stories.tsx
@@ -16,6 +16,7 @@ storiesOf('Modules/Reward Pages/Reward Details Page', module)
         onRemoveFromCart={action('remove from cart')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )
@@ -31,6 +32,7 @@ storiesOf('Modules/Reward Pages/Reward Details Page', module)
         onRemoveFromCart={action('remove from cart')}
         requiresMinecraftUsername={boolean('Requires Minecraft Username', false)}
         requiresPayPalAccount={boolean('Requires PayPal Account', false)}
+        requiresSaladCard={boolean('Requires SaladCard', false)}
         trackDisabledBuyNowClick={action('Tracks Disabled Button Click')}
       />
     )

--- a/packages/web-app/src/modules/reward/RewardStore.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.ts
@@ -6,6 +6,7 @@ import { RootStore } from '../../Store'
 import { isProblemDetail } from '../../utils'
 import { NotificationMessage, NotificationMessageCategory } from '../notifications/models'
 import { ProfileStore } from '../profile'
+import { SaladCardStore } from '../salad-card/SaladCardStore'
 import { AbortError, SaladPaymentResponse } from '../salad-pay'
 import { SaladPay } from '../salad-pay/SaladPay'
 import { Reward } from './models/Reward'
@@ -52,8 +53,10 @@ export class RewardStore {
   private checkIfFurtherActionIsRequired(reward: Reward) {
     const hasMinecraftUsername = this.profile.currentProfile?.extensions?.minecraftUsername != null
     const hasPayPalAccount = this.profile.payPalId != null
+    const hasSaladCard = this.saladCard.hasSaladCard === true
     const requiresMinecraft = reward?.tags?.includes('requires-minecraft-username') && !hasMinecraftUsername
     const requiresPayPal = reward?.tags?.includes('requires-paypal-account') && !hasPayPalAccount
+    const requiresSaladCard = reward?.tags?.includes('requires-saladcard-account') && !hasSaladCard
 
     if (requiresMinecraft) {
       this.requiresFurtherAction = true
@@ -78,12 +81,25 @@ export class RewardStore {
         type: 'error',
       })
     }
+
+    if (requiresSaladCard) {
+      this.requiresFurtherAction = true
+      this.store.notifications.sendNotification({
+        category: NotificationMessageCategory.FurtherActionRequired,
+        title: 'You must activate a SaladCard for this reward.',
+        message: 'Click to go to the enroll a SaladCard page.',
+        autoClose: false,
+        onClick: () => this.store.routing.push('/earn/saladcard'),
+        type: 'error',
+      })
+    }
   }
 
   constructor(
     private readonly store: RootStore,
     private readonly axios: AxiosInstance,
     private readonly profile: ProfileStore,
+    private readonly saladCard: SaladCardStore,
   ) {}
 
   loadReward = flow(

--- a/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
+++ b/packages/web-app/src/modules/salad-card-views/SaladCardEnrollmentPageContainer.tsx
@@ -9,7 +9,7 @@ const mapStoreToProps = (store: RootStore): any => ({
   isSubmitting: store.saladCard.isSubmitting,
   hasSaladCard: store.saladCard.hasSaladCard,
   handleRouteToStore: store.saladCard.routeToStore,
-  handleCheckForSaladCard: store.saladCard.checkForSaladCard,
+  handleLoadSaladCard: store.saladCard.loadSaladCard,
 })
 
 export const SaladCardEnrollmentPageContainer = connect(mapStoreToProps, SaladCardEnrollmentPage)

--- a/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
+++ b/packages/web-app/src/modules/salad-card-views/pages/SaladCardEnrollmentPage.tsx
@@ -31,7 +31,7 @@ interface SaladCardEnrollmentPageProps extends WithStyles<typeof styles> {
   isSubmitting: boolean
   hasSaladCard: boolean
   handleRouteToStore: () => void
-  handleCheckForSaladCard: () => void
+  handleLoadSaladCard: () => void
 }
 
 const _SaladCardEnrollmentPage = ({
@@ -42,12 +42,12 @@ const _SaladCardEnrollmentPage = ({
   isSubmitting,
   hasSaladCard,
   handleRouteToStore,
-  handleCheckForSaladCard,
+  handleLoadSaladCard,
 }: SaladCardEnrollmentPageProps) => {
   useEffect(() => {
-    handleCheckForSaladCard()
+    handleLoadSaladCard()
     hasSaladCard && handleRouteToStore()
-  }, [handleCheckForSaladCard, handleRouteToStore, hasSaladCard])
+  }, [handleLoadSaladCard, handleRouteToStore, hasSaladCard])
   return (
     <div className={classes.page}>
       <Scrollbars>

--- a/packages/web-app/src/modules/salad-card/SaladCardStore.ts
+++ b/packages/web-app/src/modules/salad-card/SaladCardStore.ts
@@ -43,7 +43,7 @@ export class SaladCardStore {
   })
 
   @action.bound
-  public checkForSaladCard = flow(function* (this: SaladCardStore) {
+  public loadSaladCard = flow(function* (this: SaladCardStore) {
     try {
       const response = yield this.axios.get('/api/v2/salad-card/cards')
       const saladCardData = response.data


### PR DESCRIPTION
Like with Minecraft and Paypal, we're now making sure users have a SaladCard before allowing them to redeem SaladCard rewards. 

If a user doesn't have a SaladCard, they'll see this red link on SaladCard rewards. 
![image](https://user-images.githubusercontent.com/37646831/168689511-d8211695-154a-4fbb-b5f8-b18c9d6c275a.png)

If users somehow do get around this check and redeem the reward without having a SaladCard, they will see this error notification. the copy will likely change later but we wanted to get a working mvp in for now.
![image](https://user-images.githubusercontent.com/37646831/168685234-3bf0bc56-7af6-47ab-a248-9be5fb74b399.png)

clicking the notification or link will take users to the enroll saladcard page