### PR TITLE
Unleash / Mixpanel integration

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "win32-x64-93",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/packages/web-app/src/FeatureManager.tsx
+++ b/packages/web-app/src/FeatureManager.tsx
@@ -36,7 +36,7 @@ export class UnleashFeatureManager implements FeatureManager {
     this.client.on("impression", (event: any) => {
       if (event.enabled) {
         if (this.analyticsStore !== undefined) {
-          this.analyticsStore.track(
+          this.analyticsStore.trackUnleashEvent(
             "$experiment_started",
             {
               "Experiment name": event.featureName,
@@ -45,13 +45,18 @@ export class UnleashFeatureManager implements FeatureManager {
           )
           if (events.length > 0) {
             events.forEach(event => {
-              this.analyticsStore.track(
-                "$experiment_started",
-                {
-                  "Experiment name": event.featureName,
-                  "Variant name": event.variant,
-                },
-              )
+              // This second conditional is necessary, implying asynchronous execution.
+              // There is probably a race condition which may cause impression events to be lost, but I don't know where.
+              // I don't know this code or this language well enough to propose a fix.
+              if (this.analyticsStore !== undefined) {
+                this.analyticsStore.trackUnleashEvent(
+                  "$experiment_started",
+                  {
+                    "Experiment name": event.featureName,
+                    "Variant name": event.variant,
+                  },
+                )
+              }
             });
             events = []
           }

--- a/packages/web-app/src/FeatureManager.tsx
+++ b/packages/web-app/src/FeatureManager.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 import { UnleashClient } from 'unleash-proxy-client'
 import type { Config } from './config'
+import { AnalyticsStore } from './modules/analytics'
 
 export interface FeatureManager {
   getVariant: (feature: string) => string
@@ -9,13 +10,15 @@ export interface FeatureManager {
   isEnabled: (feature: string) => boolean
   isEnabledCached: (feature: string) => boolean
   start: () => Promise<void>
+  setAnalyticsStore: (analyticsStore: AnalyticsStore) => void
 }
 
 export class UnleashFeatureManager implements FeatureManager {
   private readonly client: UnleashClient | undefined
   private readonly cache: Record<string, boolean>
+  private analyticsStore: AnalyticsStore | undefined
 
-  public constructor(config: Config) {
+  public constructor(config: Config, analyticsStore: AnalyticsStore | undefined) {
     this.cache = {}
     this.client = new UnleashClient({
       url: config.unleashUrl,
@@ -24,9 +27,40 @@ export class UnleashFeatureManager implements FeatureManager {
       refreshInterval: 60,
       metricsInterval: 60,
     })
+    this.analyticsStore = analyticsStore
 
     // TODO: refactor to add this at top app-level initialization
     this.start()
+
+    let events: any[] = []
+    this.client.on("impression", (event: any) => {
+      if (event.enabled) {
+        if (this.analyticsStore !== undefined) {
+          this.analyticsStore.track(
+            "$experiment_started",
+            {
+              "Experiment name": event.featureName,
+              "Variant name": event.variant,
+            },
+          )
+          if (events.length > 0) {
+            events.forEach(event => {
+              this.analyticsStore.track(
+                "$experiment_started",
+                {
+                  "Experiment name": event.featureName,
+                  "Variant name": event.variant,
+                },
+              )
+            });
+            events = []
+          }
+        }
+        else {
+          events.push(event)
+        }
+      }
+    })
   }
 
   public start = (): Promise<void> => {
@@ -83,6 +117,10 @@ export class UnleashFeatureManager implements FeatureManager {
       return value
     }
   }
+
+  public setAnalyticsStore = (analyticsStore: AnalyticsStore) => {
+    this.analyticsStore = analyticsStore
+  }
 }
 
 class DefaultFeatureManager implements FeatureManager {
@@ -97,6 +135,8 @@ class DefaultFeatureManager implements FeatureManager {
   public isEnabledCached = (): boolean => false
 
   public start = (): Promise<void> => Promise.resolve()
+
+  public setAnalyticsStore = (_analyticsStore: AnalyticsStore): void => {}
 }
 
 const FeatureManagerContext = createContext<FeatureManager>(new DefaultFeatureManager())

--- a/packages/web-app/src/Store.ts
+++ b/packages/web-app/src/Store.ts
@@ -14,7 +14,7 @@ import {
   DetectedHardwareUIStore,
   MachineSettingsUIStore,
   MachineStore,
-  NativeStore,
+  NativeStore
 } from './modules/machine'
 import { ActiveWorkloadsUIStore } from './modules/machine/ActiveWorkloadsUIStore'
 import { NotificationStore } from './modules/notifications'
@@ -133,6 +133,9 @@ export class RootStore {
     this.machineSettingsUI = new MachineSettingsUIStore(this)
     this.detectedHardwareUIStore = new DetectedHardwareUIStore(this)
     this.activeWorkloadsUIStore = new ActiveWorkloadsUIStore(this)
+
+    // Pass AnalyticsStore to FeatureManager
+    featureManager.setAnalyticsStore(this.analytics)
 
     // Start refreshing data
     this.refresh.start()

--- a/packages/web-app/src/index.tsx
+++ b/packages/web-app/src/index.tsx
@@ -50,7 +50,7 @@ if (!window.salad) {
 console.log(`Running web app build:${config.appBuild}`)
 
 const client = createClient()
-const featureManager = new UnleashFeatureManager(config)
+const featureManager = new UnleashFeatureManager(config, undefined)
 
 setTimeout(() => {
   const rootStore = createStore(client, featureManager)

--- a/packages/web-app/src/modules/analytics/AnalyticsStore.ts
+++ b/packages/web-app/src/modules/analytics/AnalyticsStore.ts
@@ -437,7 +437,7 @@ export class AnalyticsStore {
     })
   }
 
-  private track = (event: string, properties?: { [key: string]: any }) => {
+  public track = (event: string, properties?: { [key: string]: any }) => {
     if (!this.mixpanelInitialized) return
 
     mixpanel.track(event, properties)

--- a/packages/web-app/src/modules/analytics/AnalyticsStore.ts
+++ b/packages/web-app/src/modules/analytics/AnalyticsStore.ts
@@ -437,7 +437,11 @@ export class AnalyticsStore {
     })
   }
 
-  public track = (event: string, properties?: { [key: string]: any }) => {
+  public trackUnleashEvent = (event: string, properties: { [key: string]: any }) => {
+    this.track(event, properties)
+  }
+
+  private track = (event: string, properties?: { [key: string]: any }) => {
     if (!this.mixpanelInitialized) return
 
     mixpanel.track(event, properties)


### PR DESCRIPTION
There is *probably* a race condition theoretically possible that would cause events to be lost without routing to mixpanel, but I *think* that would only happen when the AnalyticsStore crashes. Hopefully this doesn't happen often? Or if it does, hopefully it bricks the program (never thought I'd say that).

I was able to verify that this code allows the program to run as normal, but I wasn't able to verify that mixpanel will get the events. None of our current feature flags have impression data enabled, and even if they did I don't actually think I have access to the mixpanel dashboard.