### PR TITLE
Remove Ethash

### DIFF
--- a/packages/web-app/src/modules/salad-bowl/definitions/linux/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/linux/index.tsx
@@ -4,12 +4,11 @@ import { createGMinerBeamHashPluginDefinitions } from './gminer-beamhash'
 import { createGMinerCuckooCyclePluginDefinitions } from './gminer-cuckoocycle'
 import { createGMinerZHashPluginDefinitions } from './gminer-zhash'
 import { createPhoenixMinerEtchashPluginDefinitions } from './phoenixminer-etchash'
-import { createPhoenixMinerEthashPluginDefinitions } from './phoenixminer-ethash'
 import { createXMRigKawPowPluginDefinitions } from './xmrig-kawpow'
 import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createLinuxPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
-  ...createPhoenixMinerEthashPluginDefinitions(accounts),
+  // Goodbye Ethash. ...createPhoenixMinerEthashPluginDefinitions(accounts),
   ...createXMRigKawPowPluginDefinitions(accounts),
   ...createPhoenixMinerEtchashPluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/index.tsx
@@ -4,17 +4,16 @@ import { createGMinerBeamHashPluginDefinitions } from './gminer-beamhash'
 import { createGMinerCuckooCyclePluginDefinitions } from './gminer-cuckoocycle'
 import { createGMinerZHashPluginDefinitions } from './gminer-zhash'
 import { createPhoenixMinerEtchashPluginDefinitions } from './phoenixminer-etchash'
-import { createPhoenixMinerEthashPluginDefinitions } from './phoenixminer-ethash'
 import { createXMRigKawPowPluginDefinitions } from './xmrig-kawpow'
 import { createXMRigRandomXPluginDefinitions } from './xmrig-randomx'
 
 export const createWindowsPluginDefinitions = (accounts: Accounts): PluginDefinition[] => [
-  ...createPhoenixMinerEthashPluginDefinitions(accounts),
-  ...createPhoenixMinerEtchashPluginDefinitions(accounts),
+  // Goodbye Ethash. ...createPhoenixMinerEthashPluginDefinitions(accounts),
   ...createXMRigKawPowPluginDefinitions(accounts),
+  ...createPhoenixMinerEtchashPluginDefinitions(accounts),
   // TODO: ...createTRexKawPowPluginDefinitions(accounts),
+  ...createGMinerZHashPluginDefinitions(accounts),
   ...createGMinerBeamHashPluginDefinitions(accounts),
   ...createGMinerCuckooCyclePluginDefinitions(accounts),
-  ...createGMinerZHashPluginDefinitions(accounts),
   ...createXMRigRandomXPluginDefinitions(accounts),
 ]

--- a/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-kawpow.tsx
+++ b/packages/web-app/src/modules/salad-bowl/definitions/windows/xmrig-kawpow.tsx
@@ -38,7 +38,7 @@ export const createXMRigKawPowPluginDefinitions = (accounts: Accounts): PluginDe
       initialRetries: 3,
       watchdogTimeout: 900000,
       errors: [...STANDARD_ERRORS],
-      requirements: [hasGpu('*', 3072)],
+      requirements: [hasGpu('*', 5120)],
     })
 
     return definitions


### PR DESCRIPTION
Removes Ethash from the legacy app in preperation for The Merge. Also re-orders a couple of algorithms, and updates the required VRAM for KawPow.
