### PR TITLE
handle redemption xp error

### DIFF
--- a/packages/web-app/src/modules/reward/RewardStore.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.ts
@@ -343,6 +343,14 @@ export class RewardStore {
                   onClick: () => window.open('https://support.salad.com/hc/en-us/articles/4405644006932', '_blank'),
                   type: 'error',
                 }
+              } else if (data.type === 'redemptions:notEnoughXp') {
+                notification = {
+                  category: NotificationMessageCategory.Error,
+                  title: 'Redemption Error',
+                  message: "This Salad account is too new to redeem. Please keep chopping with Salad and try again later.",
+                  autoClose: false,
+                  type: 'error',
+                }
               }
             }
             break


### PR DESCRIPTION
This one shows a popup when a user tries to redeem not having enough XP.

![image](https://user-images.githubusercontent.com/5437136/196247223-b9870c64-0f0b-4711-938b-2ba085d0cd23.png)
