### PR TITLE
[App - Master Branch] Make pentry icons visible

### DIFF
--- a/packages/web-app/src/modules/xp-views/components/Pantry.tsx
+++ b/packages/web-app/src/modules/xp-views/components/Pantry.tsx
@@ -39,7 +39,7 @@ interface Props extends WithStyles<typeof styles> {
   onPantryClicked: (key: string) => void
 }
 
-const getImage = (key: string) => require(`../assets/${key}/complete.png`).default
+const getImage = (key: string) => require(`../assets/${key}/complete.png`)
 
 class _Pantry extends Component<Props> {
   getColumnPositions = (percent: number): number[] =>


### PR DESCRIPTION
**Description:**
Make pentry icons visible
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/41080668/199968296-722e81f6-a5b2-44e7-9915-8239370a91e3.png">

**Issue:** https://www.notion.so/saladtech/Defect-432-Pantry-icons-invisible-69518243413d40f483fe83abdf112556