### PR TITLE
[App - Alpha Branch] Make pentry icons visible 

### DIFF
--- a/packages/web-app/src/modules/xp-views/components/Pantry.tsx
+++ b/packages/web-app/src/modules/xp-views/components/Pantry.tsx
@@ -39,7 +39,7 @@ interface Props extends WithStyles<typeof styles> {
   onPantryClicked: (key: string) => void
 }
 
-const getImage = (key: string) => require(`../assets/${key}/complete.png`).default
+const getImage = (key: string) => require(`../assets/${key}/complete.png`)
 
 class _Pantry extends Component<Props> {
   getColumnPositions = (percent: number): number[] =>


### PR DESCRIPTION
**Description:**
Make pentry icons visible
<img width="701" alt="image" src="https://user-images.githubusercontent.com/41080668/200512644-6e90dd13-a671-4e43-b451-66952d62334e.png">


**Issue:** https://www.notion.so/saladtech/Defect-432-Pantry-icons-invisible-69518243413d40f483fe83abdf112556