### PR TITLE
[App-master] Add low quantity label priority over discount label, fix one-line discount % label

### DIFF
--- a/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
@@ -92,7 +92,8 @@ const styles = (theme: SaladTheme) => ({
     letterSpacing: 1,
     paddingLeft: 5,
     paddingRight: 10,
-    marginRight: 8,
+    marginRight: 10,
+    marginBottom: 3,
     marginTop: 3,
   },
   originalPrice: {
@@ -171,7 +172,7 @@ class _RewardHeaderBar extends Component<Props> {
             <div className={classes.priceContainer}>
               {reward && reward.originalPrice && !outOfStock ? (
                 <div className={classes.priceText}>
-                  <span className={classes.originalPrice}>${reward.originalPrice}</span> ${reward.price}
+                  <span className={classes.originalPrice}>${reward.originalPrice.toFixed(2)}</span> ${reward.price}
                 </div>
               ) : (
                 <div
@@ -193,7 +194,7 @@ class _RewardHeaderBar extends Component<Props> {
                   Out of Stock
                 </div>
               )}
-              {lowQuanity && !reward?.originalPrice && (
+              {lowQuanity && (
                 <div className={classnames(classes.priceText, classes.stockLabel, classes.lowQuanityLabel)}>
                   {`${reward?.quantity} Remaining`}
                 </div>

--- a/packages/web-app/src/modules/reward-views/components/RewardItem.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardItem.tsx
@@ -100,6 +100,7 @@ const styles = (theme: SaladTheme) => ({
     paddingRight: 10,
     marginRight: 8,
     marginTop: 3,
+    alignSelf: 'flex-start',
   },
   originalPrice: {
     textDecoration: 'line-through',
@@ -118,6 +119,8 @@ class _RewardItem extends Component<Props> {
     const { reward, onClick, classes } = this.props
     let outOfStock = reward?.quantity === 0
     let lowQuanity = reward?.quantity !== undefined && reward?.quantity > 0
+    const shouldShowDiscount = reward && reward.originalPrice && !outOfStock && !lowQuanity
+
     return (
       <div key={reward?.id} className={classnames(classes.container)} onClick={onClick}>
         <AspectRatio ratio={'323/433'}>
@@ -137,14 +140,14 @@ class _RewardItem extends Component<Props> {
         <div className={classes.textContainer}>
           <div className={classes.nameText}>{reward ? reward.name : <Skeleton />}</div>
           <div className={classes.subTextContainer}>
-            {reward && reward.originalPrice && !outOfStock && (
+            {shouldShowDiscount && (
               <div className={classnames(classes.discountLabel)}>
                 {getPercentOff(reward.originalPrice, reward.price)}{' '}
               </div>
             )}
-            {reward && reward.originalPrice && !outOfStock ? (
+            {shouldShowDiscount ? (
               <div className={classes.priceText}>
-                <span className={classes.originalPrice}>{reward.originalPrice}</span> ${reward.price}
+                <span className={classes.originalPrice}>${reward.originalPrice}</span> ${reward.price}
               </div>
             ) : (
               <div className={classnames(classes.priceText, { [classes.outOfStockPrice]: outOfStock })}>
@@ -156,7 +159,7 @@ class _RewardItem extends Component<Props> {
                 Out of Stock
               </div>
             )}
-            {lowQuanity && !reward?.originalPrice && (
+            {lowQuanity && (
               <div className={classnames(classes.priceText, classes.stockLabel, classes.lowQuanityLabel)}>
                 {`${reward?.quantity} Remaining`}
               </div>

--- a/packages/web-app/src/modules/storefront-views/components/StorefrontHeroItem.tsx
+++ b/packages/web-app/src/modules/storefront-views/components/StorefrontHeroItem.tsx
@@ -181,14 +181,14 @@ class _StorefrontHeroItem extends Component<Props> {
               {heading && <div className={classes.nameText}>{heading}</div>}
               {subheading !== undefined && (
                 <div className={classes.priceContainer}>
-                  {reward && reward.originalPrice && !outOfStock && (
+                  {reward && reward.originalPrice && !outOfStock && !lowQuantity && (
                     <div className={classnames(classes.discountLabel)}>
                       {getPercentOff(reward.originalPrice, reward.price)}{' '}
                     </div>
                   )}
-                  {reward && reward.originalPrice && !outOfStock ? (
+                  {reward && reward.originalPrice && !outOfStock && !lowQuantity ? (
                     <div className={classes.priceText}>
-                      <span className={classes.originalPrice}>${reward.originalPrice}</span> ${reward.price}
+                      <span className={classes.originalPrice}>${reward.originalPrice.toFixed(2)}</span> ${reward.price}
                     </div>
                   ) : (
                     <div className={classnames(classes.priceText, { [classes.outOfStockPrice]: outOfStock })}>
@@ -200,7 +200,7 @@ class _StorefrontHeroItem extends Component<Props> {
                       Out of Stock
                     </div>
                   )}
-                  {lowQuantity && !outOfStock && !reward?.originalPrice && (
+                  {lowQuantity && !outOfStock && (
                     <div className={classnames(classes.priceText, classes.stockLabel, classes.lowQuanityLabel)}>
                       {`${quantity} Remaining`}
                     </div>

--- a/packages/web-app/src/modules/storefront-views/components/StorefrontRewardItem.tsx
+++ b/packages/web-app/src/modules/storefront-views/components/StorefrontRewardItem.tsx
@@ -144,12 +144,12 @@ class _StorefrontRewardItem extends Component<Props> {
         <div className={classes.textContainer}>
           <div className={classes.nameText}>{name ? name : <Skeleton />}</div>
           <div className={classes.subTextContainer}>
-            {rewardData && rewardData.originalPrice && !outOfStock && (
+            {rewardData && rewardData.originalPrice && !outOfStock && !lowQuantity && (
               <div className={classnames(classes.discountLabel)}>
                 {getPercentOff(rewardData.originalPrice, rewardData.price)}{' '}
               </div>
             )}
-            {originalPrice && !outOfStock ? (
+            {originalPrice && !outOfStock && !lowQuantity ? (
               <div className={classes.priceText}>
                 <span className={classes.originalPrice}>{originalPrice}</span> {price}
               </div>
@@ -163,7 +163,7 @@ class _StorefrontRewardItem extends Component<Props> {
                 Out of Stock
               </div>
             )}
-            {lowQuantity && !outOfStock && !originalPrice && (
+            {lowQuantity && !outOfStock && (
               <div className={classnames(classes.priceText, classes.stockLabel, classes.lowQuanityLabel)}>
                 {`${quantity} Remaining`}
               </div>


### PR DESCRIPTION
[1. Defect](https://www.notion.so/saladtech/Have-low-inventory-label-display-instead-of-discount-label-3f514b8188c64b8fb0185d7a93e8c5de)
[2. Defect](https://www.notion.so/saladtech/Discount-Price-Tag-shows-in-2-lines-when-smaller-screen-resolution-24af47db4c2d4b52a5f4c65c7e9615d1)

- add low quantity label priority over discount label
- fix spacing
- fix one-line discount % label

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/115642795/201099708-5897d915-f0af-4a22-bc26-11f7f16672e3.png">

<img width="908" alt="image" src="https://user-images.githubusercontent.com/115642795/201099885-050bb195-e539-4cf7-8e8e-ed5b53a34f13.png">

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/115642795/201100020-1bb54d9b-2153-49db-a2e3-596b9a977efb.png">


<img width="1093" alt="image" src="https://user-images.githubusercontent.com/115642795/201100117-bb8d6396-ea56-4b18-87c0-6c4c31d862f7.png">

