### PR TITLE
Reword redemption xp error

### DIFF
--- a/packages/web-app/src/modules/reward/RewardStore.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.ts
@@ -347,7 +347,7 @@ export class RewardStore {
                 notification = {
                   category: NotificationMessageCategory.Error,
                   title: 'Redemption Error',
-                  message: "This Salad account is too new to redeem. Please keep chopping with Salad and try again later.",
+                  message: "This Salad account is too new to redeem. You need 1440 xp to redeem rewards. Keep chopping and try again later.",
                   autoClose: false,
                   type: 'error',
                 }


### PR DESCRIPTION
Because of the numerous support messages in the discord about how much XP and time on Salad is actually required to redeem a reward, I believe the error message should be rewritten.

I changed it to the message I believe it best fits this, but feel free to change it however you see fit as long as it fits the theme of knowing how much time is required to redeem a reward, and I believe many others will be pleased.

Another way it could be worded is, "This Salad account is too new. You need 1440 XP to redeem rewards, keep chopping and try again later." 

Also note that I havent been able to check how this will fit in the box, so please do so before doing the merge.