### PR TITLE
[App - master] Fix storefront reward discount to one line

### DIFF
--- a/packages/web-app/src/modules/storefront-views/components/StorefrontRewardItem.tsx
+++ b/packages/web-app/src/modules/storefront-views/components/StorefrontRewardItem.tsx
@@ -101,6 +101,7 @@ const styles = (theme: SaladTheme) => ({
     paddingRight: 10,
     marginRight: 8,
     marginTop: 3,
+    alignSelf: 'flex-start',
   },
   originalPrice: {
     textDecoration: 'line-through',


### PR DESCRIPTION
- Fix storefront reward discount to one line
defect - https://www.notion.so/Discount-Price-Tag-shows-in-2-lines-when-smaller-screen-resolution-24af47db4c2d4b52a5f4c65c7e9615d1