### PR TITLE
RewardStore: unnecessry functionality of auto selecting the reward as…

### DIFF
--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -244,11 +244,6 @@ export class RewardStore {
 
       this.store.analytics.trackSaladPayOpened(reward)
 
-      //Automatically add the reward to the chopping cart if they don't have one selected
-      if (!this.choppingCart || this.choppingCart.length === 0) {
-        this.setSelectedTargetReward(reward)
-      }
-
       //Shows the SaladPay UI
       response = yield request.show()
 


### PR DESCRIPTION
A minor issue that was identified after the release was that if a user ever interacted with a reward, they automatically have that reward selected as target. 

https://saladtech.slack.com/archives/C04DZRDE6HM/p1680024701670059