### PR TITLE
Migrate to `salad.com` 🥗`

### DIFF
--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -1,7 +1,7 @@
 REACT_APP_BUILD=development
 
 # The scheme and host of the API. This should not end with a trailing slash.
-REACT_APP_API_URL=https://app-api.salad.io
+REACT_APP_API_URL=https://app-api.salad.com
 
 # Elastic App Search
 REACT_APP_SEARCH_URL=https://2923d060f93e44d7ba7ad4c404fa9eff.app-search.us-east-1.aws.found.io


### PR DESCRIPTION
This migrates the web application to the shiny, new API servers running on `salad.com`.