### PR TITLE
Fix PayPal account link callback URL for salad.com

### DIFF
--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -9,7 +9,7 @@ REACT_APP_SEARCH_KEY=search-rwfg8y1bakmo68v2shpqd7ag
 REACT_APP_SEARCH_ENGINE=salad-rewards-production
 
 # PayPal
-REACT_APP_PAYPAL_URL=https://www.paypal.com/connect/?flowEntry=static&client_id=AVXghg-TVgFdKBzEQ_MqWQCEAVM1ngdwl043GZvg_k9AZ1_FR0g3bKoFGIUVb2hmhCCglSRBBEXp7Zug&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%253A%252F%252Fapp-api.salad.io%252Fapi%252Fv2%252Fpaypal-account-callback
+REACT_APP_PAYPAL_URL=https://www.paypal.com/connect/?flowEntry=static&client_id=AVXghg-TVgFdKBzEQ_MqWQCEAVM1ngdwl043GZvg_k9AZ1_FR0g3bKoFGIUVb2hmhCCglSRBBEXp7Zug&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%253A%252F%252Fapp-api.salad.com%252Fapi%252Fv2%252Fpaypal-account-callback
 
 # Prohashing
 REACT_APP_PROHASHING_USERNAME=salad


### PR DESCRIPTION
This fixes the PayPal account link callback URL to use the API URL on `salad.com`.