### PR TITLE
Fix PayPal account link callback URL

### DIFF
--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -9,7 +9,7 @@ REACT_APP_SEARCH_KEY=search-rwfg8y1bakmo68v2shpqd7ag
 REACT_APP_SEARCH_ENGINE=salad-rewards-production
 
 # PayPal
-REACT_APP_PAYPAL_URL=https://www.paypal.com/connect/?flowEntry=static&client_id=AVXghg-TVgFdKBzEQ_MqWQCEAVM1ngdwl043GZvg_k9AZ1_FR0g3bKoFGIUVb2hmhCCglSRBBEXp7Zug&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%253A%252F%252Fapp-api.salad.com%252Fapi%252Fv2%252Fpaypal-account-callback
+REACT_APP_PAYPAL_URL=https://www.paypal.com/connect/?flowEntry=static&client_id=AVXghg-TVgFdKBzEQ_MqWQCEAVM1ngdwl043GZvg_k9AZ1_FR0g3bKoFGIUVb2hmhCCglSRBBEXp7Zug&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%3A%2F%2Fapp-api.salad.com%2Fapi%2Fv2%2Fpaypal-account-callback
 
 # Prohashing
 REACT_APP_PROHASHING_USERNAME=salad

--- a/packages/web-app/.env.development
+++ b/packages/web-app/.env.development
@@ -9,7 +9,7 @@ REACT_APP_SEARCH_KEY=search-qced4ibef8m4s7xacm9hoqyk
 REACT_APP_SEARCH_ENGINE=salad-rewards-test
 
 # PayPal
-REACT_APP_PAYPAL_URL=https://www.sandbox.paypal.com/connect/?flowEntry=static&client_id=AYjYnvjB968mKTIhMqUtLlNa8CJuF9rg_Q4m0Oym5gFvBkZEMPPoooXcG94OjSCjih7kI1_KM25EgfDs&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%253A%252F%252Fapp-api-testing.salad.com%252Fapi%252Fv2%252Fpaypal-account-callback
+REACT_APP_PAYPAL_URL=https://www.sandbox.paypal.com/connect/?flowEntry=static&client_id=AYjYnvjB968mKTIhMqUtLlNa8CJuF9rg_Q4m0Oym5gFvBkZEMPPoooXcG94OjSCjih7kI1_KM25EgfDs&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%3A%2F%2Fapp-api-testing.salad.com%2Fapi%2Fv2%2Fpaypal-account-callback
 
 # Prohashing
 REACT_APP_PROHASHING_USERNAME=saladtest

--- a/packages/web-app/.netlify/build.sh
+++ b/packages/web-app/.netlify/build.sh
@@ -34,7 +34,7 @@ fi
 if [[ "${PULL_REQUEST}" != 'false' || "${SITE_NAME}" =~ -test$ ]]
 then
   export REACT_APP_API_URL='https://app-api-testing.salad.com'
-  export REACT_APP_PAYPAL_URL='https://www.sandbox.paypal.com/connect/?flowEntry=static&client_id=AYjYnvjB968mKTIhMqUtLlNa8CJuF9rg_Q4m0Oym5gFvBkZEMPPoooXcG94OjSCjih7kI1_KM25EgfDs&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%253A%252F%252Fapp-api-testing.salad.com%252Fapi%252Fv2%252Fpaypal-account-callback'
+  export REACT_APP_PAYPAL_URL='https://www.sandbox.paypal.com/connect/?flowEntry=static&client_id=AYjYnvjB968mKTIhMqUtLlNa8CJuF9rg_Q4m0Oym5gFvBkZEMPPoooXcG94OjSCjih7kI1_KM25EgfDs&response_type=code&scope=openid%20email%20https%3A%2F%2Furi.paypal.com%2Fservices%2Fpaypalattributes&redirect_uri=https%3A%2F%2Fapp-api-testing.salad.com%2Fapi%2Fv2%2Fpaypal-account-callback'
   export REACT_APP_PROHASHING_USERNAME='saladtest'
   export REACT_APP_SEARCH_ENGINE='salad-rewards-test'
   export REACT_APP_SEARCH_KEY='search-qced4ibef8m4s7xacm9hoqyk'


### PR DESCRIPTION
This fixes an incorrect "double escaping" of the URL-encoded PayPal account link callback URL.