### PR TITLE
Drop npm auth token fields that were required by Netlify CI

### DIFF
--- a/packages/web-app/.azure-pipelines/deploy.ps1
+++ b/packages/web-app/.azure-pipelines/deploy.ps1
@@ -16,9 +16,9 @@ try {
     $buildDirectory = Join-Path -Path $projectRoot -ChildPath 'build'
 
     # Deploy to Netlify
-    Write-LogSection -Content 'Deploying to Netlify...'
+    Show-LogSection -Content 'Deploying to Netlify...'
     if ($Context -eq 'production') {
-        Write-LogCommand -Content "netlify deploy --dir ${buildDirectory} --prodIfUnlocked"
+        Show-LogCommand -Content "netlify deploy --dir ${buildDirectory} --prodIfUnlocked"
         & netlify deploy --dir $buildDirectory --prodIfUnlocked
         Assert-LastExitCodeSuccess -LastExecutableName 'netlify'
     }
@@ -34,20 +34,20 @@ try {
             $alias = 'no-alias'
             $message = 'no-message'
         }
-        Write-LogCommand -Content "netlify deploy --dir ${buildDirectory} --alias ${alias} --message ${message}"
+        Show-LogCommand -Content "netlify deploy --dir ${buildDirectory} --alias ${alias} --message ${message}"
         & netlify deploy --dir $buildDirectory --alias $alias --message $message
         Assert-LastExitCodeSuccess -LastExecutableName 'netlify'
     }
 }
 catch {
     if (($null -ne $_.ErrorDetails) -and ($null -ne $_.ErrorDetails.Message)) {
-        Write-LogError -Content $_.ErrorDetails.Message
+        Show-LogError -Content $_.ErrorDetails.Message
     }
     elseif (($null -ne $_.Exception) -and ($null -ne $_.Exception.Message)) {
-        Write-LogError -Content $_.Exception.Message
+        Show-LogError -Content $_.Exception.Message
     }
     else {
-        Write-LogError -Content $_
+        Show-LogError -Content $_
     }
 
     exit 1

--- a/packages/web-app/.npmrc
+++ b/packages/web-app/.npmrc
@@ -1,7 +1,1 @@
 @saladtechnologies:registry=https://pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/registry/
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/registry/:username=VssSessionToken
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/registry/:_password="${NPM_BASE64_TOKEN}"
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/registry/:email=not-used@example.com
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/:username=VssSessionToken
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/:_password="${NPM_BASE64_TOKEN}"
-//pkgs.dev.azure.com/SaladTechnologies/_packaging/SaladTechnologies/npm/:email=not-used@example.com

--- a/packages/web-app/.vscode/settings.json
+++ b/packages/web-app/.vscode/settings.json
@@ -11,8 +11,8 @@
     "typescriptreact"
   ],
   "eslint.nodePath": ".yarn/sdks",
-  "eslint.packageManager": "yarn",
   "files.associations": {
+    "**/.azure-pipelines/**/*.yaml": "azure-pipelines",
     ".env.development.local": "properties",
     ".env.development": "properties",
     ".env.production.local": "properties",


### PR DESCRIPTION
This removes the npm auth token placeholder fields in the `.npmrc` file that were required to work with 3rd party npm-compatible package repositories when running on Netlify CI.