### PR TITLE
Update CODEOWNERS to use The Kitchen team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
-* @SaladTechnologies/admins
+## The Kitchen
 
-# Administrators must approve changes to the code owners.
-CODEOWNERS @SaladTechnologies/admins
+* @SaladTechnologies/kitchen-ux-frontend
+
+## Miscellaneous
+
+# Administrators must approve changes to code owners (and other GitHub-specific resources).
+/.github/ @SaladTechnologies/admins


### PR DESCRIPTION
This updates the CODEOWNERS and sets The Kitchen UX team as the repository default.