### PR TITLE
[WebApp] saladBowlFirstLoginAt: in use instead of mocked data

### DIFF
--- a/packages/web-app/src/modules/home-views/NavigationBarContainer.tsx
+++ b/packages/web-app/src/modules/home-views/NavigationBarContainer.tsx
@@ -19,9 +19,9 @@ const mapStoreToProps = (store: RootStore): any => {
 
   const selectedAvatar = store.profile.profileAvatar
 
-  const widgetFirstLoginDate = store.profile.widgetFirstLoginDate
+  const saladBowlFirstLoginAt = store.profile.currentProfile?.saladBowlFirstLoginAt
   const isInstallReminderClosed = store.profile.isInstallReminderClosed
-  const withInstallReminder = !isInstallReminderClosed && !widgetFirstLoginDate && isAuthenticated
+  const withInstallReminder = !isInstallReminderClosed && !saladBowlFirstLoginAt && isAuthenticated
 
   const startButton = store.startButtonUI.properties
 

--- a/packages/web-app/src/modules/profile/ProfileStore.tsx
+++ b/packages/web-app/src/modules/profile/ProfileStore.tsx
@@ -77,11 +77,6 @@ export class ProfileStore {
   @observable
   public isPayPalIdDisconnectLoading: boolean = false
 
-  // TODO: the initial value has to be null (will be change after BE endpoint ready)
-  // this data should be fetched from BE
-  @observable
-  public widgetFirstLoginDate: Date | null = null
-
   @observable
   public isInstallReminderClosed: boolean = Storage.getItem(IS_INSTALL_REMINDER_CLOSED_STORAGE_KEY) === 'true'
 

--- a/packages/web-app/src/modules/profile/models/Profile.tsx
+++ b/packages/web-app/src/modules/profile/models/Profile.tsx
@@ -6,6 +6,7 @@ export interface Profile {
     minecraftUsername?: string
   }
   lastSeenApplicationVersion: string | undefined
+  saladBowlFirstLoginAt: string | undefined | null
   pendingTermsVersion: string | undefined
 }
 


### PR DESCRIPTION
https://www.notion.so/saladtech/Connect-BE-fetch-widget_first_login-data-286e07ed2d5c4787b3b9d5eb5ce7d0eb?pvs=4