### PR TITLE
[WebApp] Show Install Reminder Banner only for new users

### DIFF
--- a/packages/web-app/src/modules/home-views/NavigationBarContainer.tsx
+++ b/packages/web-app/src/modules/home-views/NavigationBarContainer.tsx
@@ -4,6 +4,8 @@ import type { RootStore } from '../../Store'
 import { connect } from '../../connect'
 import { NavigationBarWithNotifications } from './components/NavigationBarWithNotifications'
 
+const installReminderFeatureReleaseDate = new Date('2023-12-13T14:45:00.711Z')
+
 const mapStoreToProps = (store: RootStore): any => {
   const isAuthenticated = store.auth.isAuthenticated
   const handleLogin = () => {
@@ -19,9 +21,21 @@ const mapStoreToProps = (store: RootStore): any => {
 
   const selectedAvatar = store.profile.profileAvatar
 
+  const profileCreatedDate = store.profile.currentProfile?.createdAt
+    ? new Date(store.profile.currentProfile?.createdAt)
+    : null
+
+  const isProfileCreatedAfterInstallReminderReleaseDate = profileCreatedDate
+    ? profileCreatedDate > installReminderFeatureReleaseDate
+    : false
+
   const saladBowlFirstLoginAt = store.profile.currentProfile?.saladBowlFirstLoginAt
   const isInstallReminderClosed = store.profile.isInstallReminderClosed
-  const withInstallReminder = !isInstallReminderClosed && !saladBowlFirstLoginAt && isAuthenticated
+  const withInstallReminder =
+    !isInstallReminderClosed &&
+    !saladBowlFirstLoginAt &&
+    isAuthenticated &&
+    isProfileCreatedAfterInstallReminderReleaseDate
 
   const startButton = store.startButtonUI.properties
 

--- a/packages/web-app/src/modules/profile/models/Profile.tsx
+++ b/packages/web-app/src/modules/profile/models/Profile.tsx
@@ -7,6 +7,7 @@ export interface Profile {
   }
   lastSeenApplicationVersion: string | undefined
   saladBowlFirstLoginAt: string | undefined | null
+  createdAt: string | undefined
   pendingTermsVersion: string | undefined
 }
 


### PR DESCRIPTION
This date has to be changed to the actual one, before we have the feature released in production
`const installReminderFeatureReleaseDate = new Date('2023-12-13T14:45:00.711Z')`

https://www.notion.so/saladtech/Show-Install-Reminder-Banner-only-for-new-users-c4806dfbb06c4d40854ffee1fedd09c2?pvs=4