### PR TITLE
[WebApp] Add totals to mobile earn summary page

### DIFF
--- a/packages/web-app/src/modules/earn-views-mobile/MobileEarningSummaryContainer.tsx
+++ b/packages/web-app/src/modules/earn-views-mobile/MobileEarningSummaryContainer.tsx
@@ -7,9 +7,9 @@ const mapStoreToProps = (store: RootStore): any => ({
   currentBalance: store.balance.currentBalance,
   lifetimeBalance: store.balance.lifetimeBalance,
   totalXp: store.xp.currentXp,
-  last24Hr: store.balance.lastDayEarnings,
-  last7Day: store.balance.lastWeekEarnings,
-  last30Day: store.balance.lastMonthEarnings,
+  last24HrEarnings: store.balance.lastDayEarnings,
+  last7DayEarnings: store.balance.lastWeekEarnings,
+  last30DayEarnings: store.balance.lastMonthEarnings,
   earningHistory: store.balance.earningsHistory,
 })
 

--- a/packages/web-app/src/modules/earn-views-mobile/components/MobileEarningSummary.tsx
+++ b/packages/web-app/src/modules/earn-views-mobile/components/MobileEarningSummary.tsx
@@ -44,7 +44,7 @@ const _MobileEarningSummary = ({
     <div className={classes.item}>
       <StatElement
         title="Total XP"
-        values={[Math.round(totalXp || 0).toLocaleString() || '0']}
+        values={[Math.round(totalXp ?? 0).toLocaleString()]}
         infoText={`XP stands for "Experience Points". You are awarded 1 XP per minute of confirmed mining time. The more XP you have, the more veggies you will unlock in the Pantry.`}
       />
     </div>

--- a/packages/web-app/src/modules/earn-views-mobile/components/MobileEarningSummary.tsx
+++ b/packages/web-app/src/modules/earn-views-mobile/components/MobileEarningSummary.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react'
-import { Component } from 'react'
 import type { WithStyles } from 'react-jss'
 import withStyles from 'react-jss'
 import { Divider, SectionHeader, StatElement } from '../../../components'
@@ -15,45 +13,67 @@ const styles = () => ({
 
 interface Props extends WithStyles<typeof styles> {
   currentBalance?: number
+  last24HrEarnings: number
+  last7DayEarnings: number
+  last30DayEarnings: number
   lifetimeBalance?: number
   totalXp?: number
 }
 
-class _MobileEarningSummary extends Component<Props> {
-  public override render(): ReactNode {
-    const { currentBalance, lifetimeBalance, totalXp, classes } = this.props
-
-    return (
-      <div className={classes.container}>
-        <SectionHeader>Summary</SectionHeader>
-        <div className={classes.item}>
-          <StatElement
-            title={'Current Balance'}
-            values={[formatBalance(currentBalance)]}
-            infoText={'Current balance available to spend'}
-          />
-        </div>
-        <div className={classes.item}>
-          <StatElement
-            title={'Lifetime Balance'}
-            values={[formatBalance(lifetimeBalance)]}
-            infoText={'Total balance earned'}
-          />
-        </div>
-        <div className={classes.item}>
-          <StatElement
-            title={'Total XP'}
-            values={[Math.round(totalXp || 0).toLocaleString() || '0']}
-            infoText={`XP stands for "Experience Points". You are awarded 1 XP per minute of confirmed mining time. The more XP you have, the more veggies you will unlock in the Pantry.`}
-          />
-        </div>
-        <Divider />
-        <SectionHeader>Earning History</SectionHeader>
-        <EarningChartContainer />
-        <Divider />
-      </div>
-    )
-  }
-}
+const _MobileEarningSummary = ({
+  classes,
+  currentBalance,
+  last24HrEarnings,
+  last7DayEarnings,
+  last30DayEarnings,
+  lifetimeBalance,
+  totalXp,
+}: Props) => (
+  <div className={classes.container}>
+    <SectionHeader>Summary</SectionHeader>
+    <div className={classes.item}>
+      <StatElement
+        title="Current Balance"
+        values={[formatBalance(currentBalance)]}
+        infoText="Current balance available to spend"
+      />
+    </div>
+    <div className={classes.item}>
+      <StatElement title="Lifetime Balance" values={[formatBalance(lifetimeBalance)]} infoText="Total balance earned" />
+    </div>
+    <div className={classes.item}>
+      <StatElement
+        title="Total XP"
+        values={[Math.round(totalXp || 0).toLocaleString() || '0']}
+        infoText={`XP stands for "Experience Points". You are awarded 1 XP per minute of confirmed mining time. The more XP you have, the more veggies you will unlock in the Pantry.`}
+      />
+    </div>
+    <div className={classes.item}>
+      <StatElement
+        title="Earnings last 24 hours"
+        values={[formatBalance(last24HrEarnings)]}
+        infoText="Last 24 hours balance earned"
+      />
+    </div>
+    <div className={classes.item}>
+      <StatElement
+        title="Earnings last 7 days"
+        values={[formatBalance(last7DayEarnings)]}
+        infoText="Last 7 days balance earned"
+      />
+    </div>
+    <div className={classes.item}>
+      <StatElement
+        title="Earnings last 30 days"
+        values={[formatBalance(last30DayEarnings)]}
+        infoText="Last 30 days balance earned"
+      />
+    </div>
+    <Divider />
+    <SectionHeader>Earning History</SectionHeader>
+    <EarningChartContainer />
+    <Divider />
+  </div>
+)
 
 export const MobileEarningSummary = withStyles(styles)(_MobileEarningSummary)


### PR DESCRIPTION
**Description:** Add totals to mobile earn summary page

**Issue:** https://www.notion.so/saladtech/Add-counts-for-earnings-in-the-last-24-hours-7-days-and-30-days-to-the-Mobile-Earn-Summary-page-c37649345a9f4d238b699640075aef4d

<img width="339" alt="image" src="https://github.com/SaladTechnologies/salad-applications/assets/41080668/71cbeb42-ca61-45e4-abd7-3f4f8dbe1910">
