### PR TITLE
[WebApp] getPasskeyCredential: credentials mediation set to conditional

### DIFF
--- a/packages/web-app/src/modules/passkey-setup/utils.ts
+++ b/packages/web-app/src/modules/passkey-setup/utils.ts
@@ -189,8 +189,7 @@ export const getPasskeyCredential = async (
   const credential = (await navigator.credentials.get({
     publicKey: publicKeyCredentialRequestOptions,
     signal: abortController.signal,
-    // Specify 'conditional' to activate conditional UI
-    mediation: 'conditional',
+    mediation: 'optional',
   })) as AssertedCredentialResponse
 
   return credential


### PR DESCRIPTION
 getPasskeyCredential: credentials mediation set to conditional
 to resolve Bitwarden passkey login issue 