### PR TITLE
[Web App] Add account panel to manage Solana wallet address

### DIFF
--- a/packages/web-app/src/Store.tsx
+++ b/packages/web-app/src/Store.tsx
@@ -22,6 +22,7 @@ import { ProfileStore } from './modules/profile'
 import type { Profile } from './modules/profile/models'
 import { ReferralStore } from './modules/referral'
 import { RewardStore } from './modules/reward'
+import { SolanaWalletStore } from './modules/solana-wallet'
 import { StartButtonUIStore } from './modules/start-button/StartButtonUIStore'
 import { StorefrontStore } from './modules/storefront/StorefrontStore'
 import { TermsAndConditionsStore } from './modules/terms-and-conditions'
@@ -75,6 +76,7 @@ export class RootStore {
   public readonly backupCodes: BackupCodesStore
   public readonly demandMonitor: DemandMonitorStore
   public readonly demandAlerts: DemandAlertsStore
+  public readonly solanaWallet: SolanaWalletStore
 
   constructor(axios: AxiosInstance, private readonly featureManager: FeatureManager) {
     this.routing = new RouterStore()
@@ -103,6 +105,7 @@ export class RootStore {
     this.errorBoundary = new ErrorBoundaryStore()
     this.demandMonitor = new DemandMonitorStore(axios)
     this.demandAlerts = new DemandAlertsStore(axios)
+    this.solanaWallet = new SolanaWalletStore(this, axios)
 
     // Pass AnalyticsStore to FeatureManager
     featureManager.setAnalyticsStore(this.analytics)

--- a/packages/web-app/src/modules/account-views/account-views/components/Account.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/Account.tsx
@@ -10,9 +10,11 @@ import { Head } from '../../../../components'
 import { withLogin } from '../../../auth-views'
 import { type Passkey } from '../../../passkey-setup'
 import type { Avatar, Profile } from '../../../profile/models'
+import { SOLANA_WALLET_ENABLED } from '../../../solana-wallet/constants'
 import { AccountSecurityContainer } from './AccountSecurity/AccountSecurityContainer'
 import { AccountTermsAndConditionsUpdate } from './AccountTermsAndConditionsUpdate'
 import { GoogleSignInForm } from './GoogleSignInForm'
+import { SolanaWalletContainer } from './SolanaWallet'
 
 const styles = (theme: SaladTheme) => ({
   container: {
@@ -246,6 +248,7 @@ const _Account: FC<Props> = ({
             </div>
           </div>
           <AccountSecurityContainer />
+          {SOLANA_WALLET_ENABLED && <SolanaWalletContainer />}
         </Layout>
       </Scrollbars>
     </div>

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.stories.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.stories.tsx
@@ -1,0 +1,28 @@
+import { action } from '@storybook/addon-actions'
+import { boolean, select } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+import type { SolanaWalletSubmitStatus } from '../../../../solana-wallet'
+import { SolanaWallet } from './SolanaWallet'
+
+const submitStatuses: SolanaWalletSubmitStatus[] = ['unknown', 'loading', 'success', 'failure']
+
+storiesOf('Modules/Account/AccountViews/components/SolanaWallet', module).add('default', () => {
+  const hasWallet = boolean('Has Wallet', true)
+  const walletAddress = hasWallet ? '5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1' : undefined
+  const submitStatus = select<SolanaWalletSubmitStatus>('submitStatus', submitStatuses, 'unknown')
+
+  return (
+    <div style={{ backgroundColor: '#0A2133', padding: 24 }}>
+      <SolanaWallet
+        walletAddress={walletAddress}
+        isLoading={boolean('isLoading', false)}
+        isLoadError={boolean('isLoadError', false)}
+        submitStatus={submitStatus}
+        loadWallet={action('loadWallet')}
+        setWallet={action('setWallet')}
+        clearWallet={action('clearWallet')}
+        setSubmitStatus={action('setSubmitStatus')}
+      />
+    </div>
+  )
+})

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.styles.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.styles.tsx
@@ -1,0 +1,53 @@
+import type CSS from 'csstype'
+
+export const styles: () => Record<string, CSS.Properties> = () => ({
+  solanaWalletWrapper: {
+    flex: 1,
+    marginTop: '56px',
+    maxWidth: '400px',
+  },
+  description: {
+    paddingTop: '16px',
+  },
+  content: {
+    paddingTop: '24px',
+    width: '100%',
+  },
+  fieldContainer: {
+    maxWidth: '400px',
+  },
+  savedAddressLabel: {
+    paddingBottom: '4px',
+  },
+  savedAddressRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: '12px',
+  },
+  savedAddress: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  copyIcon: {
+    cursor: 'pointer',
+  },
+  buttonRow: {
+    marginTop: '16px',
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '12px',
+  },
+  messageWrapper: {
+    marginTop: '16px',
+    minHeight: '40px',
+  },
+  confirmWrapper: {
+    marginTop: '16px',
+  },
+  confirmText: {
+    paddingBottom: '12px',
+  },
+})

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
@@ -1,0 +1,191 @@
+import { faCopy, faPenToSquare, faTrashCan } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button, Text, TextField } from '@saladtechnologies/garden-components'
+import { useEffect, useState, type FC } from 'react'
+import type { WithStyles } from 'react-jss'
+import withStyles from 'react-jss'
+import { ErrorText } from '../../../../../components'
+import { SuccessText } from '../../../../../components/primitives/content/SuccessText'
+import type { SolanaWalletSubmitStatus } from '../../../../solana-wallet'
+import { solanaWalletAddressRegex } from '../../../../solana-wallet/constants'
+import type { FormValues } from '../Account'
+import { styles } from './SolanaWallet.styles'
+
+interface Props extends WithStyles<typeof styles> {
+  walletAddress?: string
+  isLoading: boolean
+  isLoadError: boolean
+  submitStatus: SolanaWalletSubmitStatus
+  loadWallet: () => void
+  setWallet: (walletAddress: string) => void
+  clearWallet: () => void
+  setSubmitStatus: (submitStatus: SolanaWalletSubmitStatus) => void
+}
+
+const _SolanaWallet: FC<Props> = ({
+  classes,
+  walletAddress,
+  isLoading,
+  isLoadError,
+  submitStatus,
+  loadWallet,
+  setWallet,
+  clearWallet,
+  setSubmitStatus,
+}) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isConfirmingRemoval, setIsConfirmingRemoval] = useState(false)
+
+  const isSubmitting = submitStatus === 'loading'
+  const isSubmitSuccess = submitStatus === 'success'
+  const isSubmitFailure = submitStatus === 'failure'
+
+  useEffect(() => {
+    loadWallet()
+    return () => setSubmitStatus('unknown')
+  }, [loadWallet, setSubmitStatus])
+
+  // Once a save/clear succeeds, drop out of the edit/confirm states.
+  useEffect(() => {
+    if (isSubmitSuccess) {
+      setIsEditing(false)
+      setIsConfirmingRemoval(false)
+    }
+  }, [isSubmitSuccess])
+
+  const handleSubmit = (data: FormValues) => {
+    if (data.input) {
+      setWallet(data.input.trim())
+    }
+  }
+
+  const handleCopy = () => {
+    if (walletAddress) {
+      navigator.clipboard?.writeText(walletAddress)
+    }
+  }
+
+  const showForm = isEditing || !walletAddress
+
+  return (
+    <div className={classes.solanaWalletWrapper}>
+      <Text variant="baseXL">Solana Wallet</Text>
+      <div className={classes.description}>
+        <Text variant="baseS">
+          Add the Solana wallet address where you’d like to receive RENDER token rewards. Make sure this address is
+          correct — token rewards sent to the wrong address cannot be recovered.
+        </Text>
+      </div>
+
+      <div className={classes.content}>
+        {isLoading ? (
+          <Text variant="baseS">Loading your wallet…</Text>
+        ) : (
+          <>
+            {showForm ? (
+              <div className={classes.fieldContainer}>
+                <TextField
+                  isSubmitting={isSubmitting}
+                  isSubmitSuccess={isSubmitSuccess}
+                  validationRegex={solanaWalletAddressRegex}
+                  validationRegexErrorMessage="Enter a valid Solana wallet address (32 - 44 base58 characters)."
+                  label="Solana Wallet Address"
+                  onSubmit={handleSubmit}
+                  onFocus={() => isSubmitFailure && setSubmitStatus('unknown')}
+                  defaultValue={walletAddress}
+                />
+                {isEditing && walletAddress && (
+                  <div className={classes.buttonRow}>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      label="Cancel"
+                      onClick={() => {
+                        setIsEditing(false)
+                        setSubmitStatus('unknown')
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
+                <div className={classes.savedAddressLabel}>
+                  <Text variant="baseS">Your Solana Wallet Address</Text>
+                </div>
+                <div className={classes.savedAddressRow}>
+                  <Text variant="baseM" className={classes.savedAddress}>
+                    {walletAddress}
+                  </Text>
+                  <FontAwesomeIcon
+                    icon={faCopy}
+                    className={classes.copyIcon}
+                    title="Copy address"
+                    onClick={handleCopy}
+                  />
+                </div>
+                {!isConfirmingRemoval ? (
+                  <div className={classes.buttonRow}>
+                    <Button
+                      variant="primary"
+                      size="small"
+                      label="Edit"
+                      leadingIcon={<FontAwesomeIcon icon={faPenToSquare} />}
+                      onClick={() => {
+                        setSubmitStatus('unknown')
+                        setIsEditing(true)
+                      }}
+                    />
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      label="Remove"
+                      leadingIcon={<FontAwesomeIcon icon={faTrashCan} />}
+                      onClick={() => setIsConfirmingRemoval(true)}
+                    />
+                  </div>
+                ) : (
+                  <div className={classes.confirmWrapper}>
+                    <div className={classes.confirmText}>
+                      <Text variant="baseS">
+                        Are you sure you want to remove this wallet address? You will no longer receive RENDER token
+                        rewards until you add a new one.
+                      </Text>
+                    </div>
+                    <div className={classes.buttonRow}>
+                      <Button
+                        variant="primary"
+                        size="small"
+                        label="Yes, remove"
+                        isLoading={isSubmitting}
+                        onClick={() => clearWallet()}
+                      />
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        label="Cancel"
+                        onClick={() => setIsConfirmingRemoval(false)}
+                      />
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            <div className={classes.messageWrapper}>
+              {isSubmitSuccess && <SuccessText>Success! Your Solana wallet has been updated.</SuccessText>}
+              {isSubmitFailure && (
+                <ErrorText>There was an error updating your Solana wallet. Please try again.</ErrorText>
+              )}
+              {isLoadError && !isSubmitFailure && (
+                <ErrorText>Unable to load your Solana wallet. Please refresh the page.</ErrorText>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const SolanaWallet = withStyles(styles)(_SolanaWallet)

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
@@ -88,6 +88,8 @@ const _SolanaWallet: FC<Props> = ({
                   isSubmitSuccess={isSubmitSuccess}
                   label="Solana Wallet Address"
                   onSubmit={handleSubmit}
+                  validationRegex={/^[1-9A-HJ-NP-Za-km-z]{32,44}$/}
+                  validationRegexErrorMessage="Enter a valid Solana wallet address (32-44 base58 characters)."
                   onFocus={() => isSubmitFailure && setSubmitStatus('unknown')}
                   defaultValue={walletAddress}
                 />

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWallet.tsx
@@ -7,7 +7,6 @@ import withStyles from 'react-jss'
 import { ErrorText } from '../../../../../components'
 import { SuccessText } from '../../../../../components/primitives/content/SuccessText'
 import type { SolanaWalletSubmitStatus } from '../../../../solana-wallet'
-import { solanaWalletAddressRegex } from '../../../../solana-wallet/constants'
 import type { FormValues } from '../Account'
 import { styles } from './SolanaWallet.styles'
 
@@ -87,8 +86,6 @@ const _SolanaWallet: FC<Props> = ({
                 <TextField
                   isSubmitting={isSubmitting}
                   isSubmitSuccess={isSubmitSuccess}
-                  validationRegex={solanaWalletAddressRegex}
-                  validationRegexErrorMessage="Enter a valid Solana wallet address (32 - 44 base58 characters)."
                   label="Solana Wallet Address"
                   onSubmit={handleSubmit}
                   onFocus={() => isSubmitFailure && setSubmitStatus('unknown')}

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWalletContainer.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/SolanaWalletContainer.tsx
@@ -1,0 +1,16 @@
+import { connect } from '../../../../../connect'
+import type { RootStore } from '../../../../../Store'
+import { SolanaWallet } from './SolanaWallet'
+
+const mapStoreToProps = (store: RootStore): any => ({
+  walletAddress: store.solanaWallet.walletAddress,
+  isLoading: store.solanaWallet.isLoading,
+  isLoadError: store.solanaWallet.isLoadError,
+  submitStatus: store.solanaWallet.submitStatus,
+  loadWallet: store.solanaWallet.loadWallet,
+  setWallet: store.solanaWallet.setWallet,
+  clearWallet: store.solanaWallet.clearWallet,
+  setSubmitStatus: store.solanaWallet.setSubmitStatus,
+})
+
+export const SolanaWalletContainer = connect(mapStoreToProps, SolanaWallet)

--- a/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/index.ts
+++ b/packages/web-app/src/modules/account-views/account-views/components/SolanaWallet/index.ts
@@ -1,0 +1,1 @@
+export * from './SolanaWalletContainer'

--- a/packages/web-app/src/modules/solana-wallet/SolanaWalletStore.tsx
+++ b/packages/web-app/src/modules/solana-wallet/SolanaWalletStore.tsx
@@ -1,0 +1,97 @@
+import type { AxiosInstance, AxiosResponse } from 'axios'
+import { action, computed, flow, observable } from 'mobx'
+import type { RootStore } from '../../Store'
+import { NotificationMessageCategory } from '../notifications/models'
+import { solanaWalletEndpointPath } from './constants'
+import type { SolanaWallet } from './models'
+
+export type SolanaWalletSubmitStatus = 'unknown' | 'loading' | 'success' | 'failure'
+
+export class SolanaWalletStore {
+  /** The Chef's currently saved Solana wallet address, if any. */
+  @observable
+  public walletAddress?: string
+
+  /** Whether the initial `GET` of the wallet is in flight. */
+  @observable
+  public isLoading: boolean = false
+
+  /** Whether the most recent load failed. */
+  @observable
+  public isLoadError: boolean = false
+
+  /** Status of the most recent set/clear mutation. */
+  @observable
+  public submitStatus: SolanaWalletSubmitStatus = 'unknown'
+
+  constructor(private readonly store: RootStore, private readonly axios: AxiosInstance) {}
+
+  @computed
+  public get hasWallet(): boolean {
+    return !!this.walletAddress
+  }
+
+  @action.bound
+  public setSubmitStatus = (submitStatus: SolanaWalletSubmitStatus) => {
+    this.submitStatus = submitStatus
+  }
+
+  @action.bound
+  public loadWallet = flow(function* (this: SolanaWalletStore) {
+    this.isLoading = true
+    this.isLoadError = false
+    try {
+      const response: AxiosResponse<SolanaWallet> = yield this.axios.get(solanaWalletEndpointPath)
+      this.walletAddress = response.data?.walletAddress || undefined
+    } catch (err) {
+      this.isLoadError = true
+      this.walletAddress = undefined
+    } finally {
+      this.isLoading = false
+    }
+  })
+
+  @action.bound
+  public setWallet = flow(function* (this: SolanaWalletStore, walletAddress: string) {
+    if (this.submitStatus === 'loading') {
+      return
+    }
+    this.submitStatus = 'loading'
+    try {
+      const response: AxiosResponse<SolanaWallet> = yield this.axios.post(solanaWalletEndpointPath, { walletAddress })
+      this.walletAddress = response.data?.walletAddress ?? walletAddress
+      this.submitStatus = 'success'
+    } catch (err) {
+      this.submitStatus = 'failure'
+      this.store.notifications.sendNotification({
+        category: NotificationMessageCategory.FurtherActionRequired,
+        title: 'Unable to save your Solana wallet address',
+        message: 'Please double check the address and try again.',
+        autoClose: false,
+        type: 'error',
+      })
+    }
+  })
+
+  @action.bound
+  public clearWallet = flow(function* (this: SolanaWalletStore) {
+    if (this.submitStatus === 'loading') {
+      return
+    }
+    this.submitStatus = 'loading'
+    try {
+      yield this.axios.delete(solanaWalletEndpointPath)
+      this.walletAddress = undefined
+      this.submitStatus = 'success'
+    } catch (err) {
+      this.submitStatus = 'failure'
+      this.store.notifications.sendNotification({
+        category: NotificationMessageCategory.FurtherActionRequired,
+        title: 'Unable to remove your Solana wallet address',
+        message: 'Please try again.',
+        autoClose: false,
+        type: 'error',
+      })
+    }
+  })
+}

--- a/packages/web-app/src/modules/solana-wallet/constants.tsx
+++ b/packages/web-app/src/modules/solana-wallet/constants.tsx
@@ -6,15 +6,7 @@
  * is flipped to `true`. This is intentionally a simple compile-time constant
  * rather than a remote flag so it can be safely shipped in the off state.
  */
-export const SOLANA_WALLET_ENABLED = false
+export const SOLANA_WALLET_ENABLED = false;
 
 /** Endpoint used to get/set/clear the authenticated user's Solana wallet address. */
-export const solanaWalletEndpointPath = '/api/v2/solana/wallet'
-
-/**
- * Validates a Solana wallet address.
- *
- * Solana addresses are base58 encoded public keys, which are 32 - 44 characters
- * long and never contain the ambiguous base58 characters `0`, `O`, `I` or `l`.
- */
-export const solanaWalletAddressRegex = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+export const solanaWalletEndpointPath = "/api/v2/solana/wallet";

--- a/packages/web-app/src/modules/solana-wallet/constants.tsx
+++ b/packages/web-app/src/modules/solana-wallet/constants.tsx
@@ -1,0 +1,20 @@
+/**
+ * Hard-coded feature flag that gates the Solana wallet account panel.
+ *
+ * The RENDER token integration is still undergoing integration testing, so the
+ * panel (and any navigation entry that links to it) must stay hidden until this
+ * is flipped to `true`. This is intentionally a simple compile-time constant
+ * rather than a remote flag so it can be safely shipped in the off state.
+ */
+export const SOLANA_WALLET_ENABLED = false
+
+/** Endpoint used to get/set/clear the authenticated user's Solana wallet address. */
+export const solanaWalletEndpointPath = '/api/v2/solana/wallet'
+
+/**
+ * Validates a Solana wallet address.
+ *
+ * Solana addresses are base58 encoded public keys, which are 32 - 44 characters
+ * long and never contain the ambiguous base58 characters `0`, `O`, `I` or `l`.
+ */
+export const solanaWalletAddressRegex = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/

--- a/packages/web-app/src/modules/solana-wallet/index.tsx
+++ b/packages/web-app/src/modules/solana-wallet/index.tsx
@@ -1,0 +1,1 @@
+export * from './SolanaWalletStore'

--- a/packages/web-app/src/modules/solana-wallet/models/SolanaWallet.tsx
+++ b/packages/web-app/src/modules/solana-wallet/models/SolanaWallet.tsx
@@ -4,6 +4,11 @@
  * Mirrors the payload returned by `GET /api/v2/solana/wallet`.
  */
 export interface SolanaWallet {
-  /** The Solana wallet address (base58 encoded public key). */
-  walletAddress: string
+  /**
+   * The Solana wallet address (base58 encoded public key).
+   *
+   * Optional because a Chef may not have set a wallet address yet, in which
+   * case `GET /api/v2/solana/wallet` returns no address.
+   */
+  walletAddress?: string
 }

--- a/packages/web-app/src/modules/solana-wallet/models/SolanaWallet.tsx
+++ b/packages/web-app/src/modules/solana-wallet/models/SolanaWallet.tsx
@@ -1,0 +1,9 @@
+/**
+ * Represents a Chef's Solana wallet used for RENDER token rewards.
+ *
+ * Mirrors the payload returned by `GET /api/v2/solana/wallet`.
+ */
+export interface SolanaWallet {
+  /** The Solana wallet address (base58 encoded public key). */
+  walletAddress: string
+}

--- a/packages/web-app/src/modules/solana-wallet/models/index.tsx
+++ b/packages/web-app/src/modules/solana-wallet/models/index.tsx
@@ -1,0 +1,1 @@
+export * from './SolanaWallet'


### PR DESCRIPTION
## Goal
Add an account settings panel in the **salad-applications** web app that lets a Chef view, set, and clear their Solana wallet address (used for RENDER token rewards). The entire panel must be gated behind a **hard-coded feature flag** so it stays hidden until integration testing is complete.

## Relevant APIs (from project brief)
- `GET /api/v2/solana/wallet` — fetch the authenticated user's current Solana wallet address.
- `POST /api/v2/solana/wallet` — set/update the wallet address.
- `DELETE /api/v2/solana/wallet` — clear the wallet address.

## Approach
1. **Locate the account area.** Find where existing account/profile settings panels live (e.g. the account/settings page that renders things like email, password, payout/withdraw, or notification preferences). Mirror that structure, routing, and styling so the new panel feels native. Identify the shared patterns used for data fetching (likely a hooks/store layer — Redux, RxJS epics, React Query, or similar — match whatever the repo uses) and form submission.
2. **Add the feature flag.** Introduce a hard-coded boolean constant (e.g. `SOLANA_WALLET_ENABLED = false`) in the appropriate config/feature-flag module. Wrap the panel's rendering and any nav/menu entry so nothing appears when the flag is off. Keep it a simple compile-time constant per the task (no remote flag service).
3. **API client layer.** Add typed client functions for the three wallet endpoints, following the repo's existing API/service conventions (base URL, auth headers/interceptors, error handling). Define a `SolanaWallet` type/model.
4. **State / data hook.** Add a hook or store slice that loads the current wallet on mount (`GET`), and exposes `setWallet` (`POST`) and `clearWallet` (`DELETE`) actions with loading/error state, optimistic or post-response refresh.
5. **UI component — `SolanaWalletPanel`.**
   - Empty state: input field + "Add wallet" / Save button.
   - Populated state: display the saved address (with truncation/copy affordance) plus Edit and Remove actions.
   - Client-side validation of Solana address format (base58, ~32–44 chars) before submit; surface server validation errors.
   - Loading and error UI consistent with other account panels.
   - Confirmation prompt before clearing (DELETE).
6. **Wire into the account page** behind the feature flag, including any sidebar/menu navigation entry if account panels are individually navigable.
7. **Verify** the existing Next.js conventions in this repo before coding (per AGENTS.md, read the relevant guide in `node_modules/next/dist/docs/` — this is a modified Next.js with breaking changes) and follow established component/test patterns. Add unit tests for the API client and component states (empty, populated, validation error, server error), and confirm the panel is invisible when the flag is off.

## Acceptance criteria
- With the flag ON: Chef can add, view, edit, and remove a Solana wallet address; all three endpoints are exercised correctly with proper auth and error handling.
- With the flag OFF (default committed value): the panel and any nav entry are completely hidden.
- Address validation prevents obviously invalid submissions; server errors are surfaced gracefully.
- Styling and structure match existing account panels.