### PR TITLE
[Web App] Add price quotes to RENDER rewards

### DIFF
--- a/packages/web-app/src/FeatureManager.tsx
+++ b/packages/web-app/src/FeatureManager.tsx
@@ -9,7 +9,6 @@ export enum FeatureFlags {
   DemandMonitor = 'app_DemandMonitor',
   DemandNotifications = 'app_DemandNotifications',
   FleetDashboard = 'app_fleetdashboard',
-  RenderPriceQuotes = 'app_RenderPriceQuotes',
 }
 
 export interface FeatureManager {

--- a/packages/web-app/src/FeatureManager.tsx
+++ b/packages/web-app/src/FeatureManager.tsx
@@ -9,6 +9,7 @@ export enum FeatureFlags {
   DemandMonitor = 'app_DemandMonitor',
   DemandNotifications = 'app_DemandNotifications',
   FleetDashboard = 'app_fleetdashboard',
+  RenderPriceQuotes = 'app_RenderPriceQuotes',
 }
 
 export interface FeatureManager {

--- a/packages/web-app/src/Store.tsx
+++ b/packages/web-app/src/Store.tsx
@@ -21,6 +21,7 @@ import { PasskeyStore } from './modules/passkey-setup'
 import { ProfileStore } from './modules/profile'
 import type { Profile } from './modules/profile/models'
 import { ReferralStore } from './modules/referral'
+import { RenderStore } from './modules/render'
 import { RewardStore } from './modules/reward'
 import { StartButtonUIStore } from './modules/start-button/StartButtonUIStore'
 import { StorefrontStore } from './modules/storefront/StorefrontStore'
@@ -56,6 +57,7 @@ export class RootStore {
   public readonly routing: RouterStore
   public readonly xp: ExperienceStore
   public readonly rewards: RewardStore
+  public readonly render: RenderStore
   public readonly balance: BalanceStore
   public readonly profile: ProfileStore
   public readonly ui: UIStore
@@ -86,6 +88,7 @@ export class RootStore {
     this.profile = new ProfileStore(this, axios)
     this.termsAndConditions = new TermsAndConditionsStore(axios, this.profile)
     this.rewards = new RewardStore(this, axios, this.profile)
+    this.render = new RenderStore(axios, featureManager)
     this.analytics = new AnalyticsStore(this.auth)
     this.balance = new BalanceStore(axios)
     this.ui = new UIStore(this)

--- a/packages/web-app/src/Store.tsx
+++ b/packages/web-app/src/Store.tsx
@@ -88,7 +88,7 @@ export class RootStore {
     this.profile = new ProfileStore(this, axios)
     this.termsAndConditions = new TermsAndConditionsStore(axios, this.profile)
     this.rewards = new RewardStore(this, axios, this.profile)
-    this.render = new RenderStore(axios, featureManager)
+    this.render = new RenderStore(axios)
     this.analytics = new AnalyticsStore(this.auth)
     this.balance = new BalanceStore(axios)
     this.ui = new UIStore(this)

--- a/packages/web-app/src/modules/analytics/AnalyticsStore.tsx
+++ b/packages/web-app/src/modules/analytics/AnalyticsStore.tsx
@@ -184,6 +184,17 @@ export class AnalyticsStore {
     })
   }
 
+  /** Track when a RENDER price quote is viewed on a reward. */
+  public trackRenderPriceQuoteViewed = (reward: Reward, tokenAmount?: number, rate?: number) => {
+    this.track('Render Price Quote Viewed', {
+      RewardId: reward.id,
+      RewardName: reward.name,
+      RewardPrice: reward.price,
+      RenderTokenAmount: tokenAmount,
+      RenderUsdRate: rate,
+    })
+  }
+
   /** Track when a reward category is viewed */
   public trackRewardSearch = (searchTerm: string) => {
     this.track('Reward Search', {

--- a/packages/web-app/src/modules/render/RenderStore.test.ts
+++ b/packages/web-app/src/modules/render/RenderStore.test.ts
@@ -1,23 +1,12 @@
 import type { AxiosInstance } from 'axios'
-import type { FeatureManager } from '../../FeatureManager'
 import { RenderStore } from './RenderStore'
-
-const makeFeatureManager = (enabled: boolean): FeatureManager => ({
-  getVariant: () => 'disabled',
-  handleLogin: () => {},
-  handleLogout: () => {},
-  isEnabled: () => enabled,
-  isEnabledCached: () => enabled,
-  start: () => Promise.resolve(),
-  setAnalyticsStore: () => {},
-})
 
 const makeAxios = (get: jest.Mock): AxiosInstance => ({ get } as unknown as AxiosInstance)
 
 describe('RenderStore', () => {
   it('does not fetch when the feature flag is off', async () => {
     const get = jest.fn()
-    const store = new RenderStore(makeAxios(get), makeFeatureManager(false))
+    const store = new RenderStore(makeAxios(get), false)
 
     await store.fetchExchangeRate()
 
@@ -28,7 +17,7 @@ describe('RenderStore', () => {
 
   it('does not poll when the feature flag is off', () => {
     const get = jest.fn()
-    const store = new RenderStore(makeAxios(get), makeFeatureManager(false))
+    const store = new RenderStore(makeAxios(get), false)
 
     store.startPollingExchangeRate()
 
@@ -39,7 +28,7 @@ describe('RenderStore', () => {
     const get = jest.fn().mockResolvedValue({
       data: { rate: 2.5, asOf: '2026-06-24T00:00:00.000Z', expiresAt: '2026-06-24T00:01:00.000Z' },
     })
-    const store = new RenderStore(makeAxios(get), makeFeatureManager(true))
+    const store = new RenderStore(makeAxios(get), true)
 
     await store.fetchExchangeRate()
 
@@ -51,7 +40,7 @@ describe('RenderStore', () => {
 
   it('flags an error and clears loading when the request fails', async () => {
     const get = jest.fn().mockRejectedValue(new Error('boom'))
-    const store = new RenderStore(makeAxios(get), makeFeatureManager(true))
+    const store = new RenderStore(makeAxios(get), true)
 
     await store.fetchExchangeRate()
 

--- a/packages/web-app/src/modules/render/RenderStore.test.ts
+++ b/packages/web-app/src/modules/render/RenderStore.test.ts
@@ -1,0 +1,62 @@
+import type { AxiosInstance } from 'axios'
+import type { FeatureManager } from '../../FeatureManager'
+import { RenderStore } from './RenderStore'
+
+const makeFeatureManager = (enabled: boolean): FeatureManager => ({
+  getVariant: () => 'disabled',
+  handleLogin: () => {},
+  handleLogout: () => {},
+  isEnabled: () => enabled,
+  isEnabledCached: () => enabled,
+  start: () => Promise.resolve(),
+  setAnalyticsStore: () => {},
+})
+
+const makeAxios = (get: jest.Mock): AxiosInstance => ({ get } as unknown as AxiosInstance)
+
+describe('RenderStore', () => {
+  it('does not fetch when the feature flag is off', async () => {
+    const get = jest.fn()
+    const store = new RenderStore(makeAxios(get), makeFeatureManager(false))
+
+    await store.fetchExchangeRate()
+
+    expect(get).not.toHaveBeenCalled()
+    expect(store.exchangeRate).toBeUndefined()
+    expect(store.isLoadingExchangeRate).toBe(false)
+  })
+
+  it('does not poll when the feature flag is off', () => {
+    const get = jest.fn()
+    const store = new RenderStore(makeAxios(get), makeFeatureManager(false))
+
+    store.startPollingExchangeRate()
+
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('fetches and stores the quote when the flag is on', async () => {
+    const get = jest.fn().mockResolvedValue({
+      data: { rate: 2.5, asOf: '2026-06-24T00:00:00.000Z', expiresAt: '2026-06-24T00:01:00.000Z' },
+    })
+    const store = new RenderStore(makeAxios(get), makeFeatureManager(true))
+
+    await store.fetchExchangeRate()
+
+    expect(get).toHaveBeenCalledWith('/api/v2/render/exchange-rate')
+    expect(store.exchangeRate?.rate).toBe(2.5)
+    expect(store.hasExchangeRateError).toBe(false)
+    expect(store.isLoadingExchangeRate).toBe(false)
+  })
+
+  it('flags an error and clears loading when the request fails', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('boom'))
+    const store = new RenderStore(makeAxios(get), makeFeatureManager(true))
+
+    await store.fetchExchangeRate()
+
+    expect(store.hasExchangeRateError).toBe(true)
+    expect(store.exchangeRate).toBeUndefined()
+    expect(store.isLoadingExchangeRate).toBe(false)
+  })
+})

--- a/packages/web-app/src/modules/render/RenderStore.tsx
+++ b/packages/web-app/src/modules/render/RenderStore.tsx
@@ -1,16 +1,14 @@
 import type { AxiosInstance, AxiosResponse } from 'axios'
 import { action, flow, observable } from 'mobx'
-import type { FeatureManager } from '../../FeatureManager'
-import { FeatureFlags } from '../../FeatureManager'
-import { renderExchangeRateEndpointPath, renderExchangeRateRefreshRate } from './constants'
+import { renderExchangeRateEndpointPath, renderExchangeRateRefreshRate, renderPriceQuotesEnabled } from './constants'
 import type { RenderExchangeRate, RenderExchangeRateResource } from './models'
 import { isExchangeRateStale, renderExchangeRateFromResource } from './utils'
 
 /**
  * Owns the live RENDER/USD price quote that powers the price-quote feature.
  *
- * All fetching is gated behind the {@link FeatureFlags.RenderPriceQuotes} flag: when the flag is off the store never
- * touches the network and `exchangeRate` stays `undefined`.
+ * All fetching is gated behind the internal {@link renderPriceQuotesEnabled} flag: when the flag is off the store
+ * never touches the network and `exchangeRate` stays `undefined`.
  */
 export class RenderStore {
   @observable
@@ -25,11 +23,16 @@ export class RenderStore {
   private pollingHandle?: ReturnType<typeof setInterval>
   private activeViewers: number = 0
 
-  public constructor(private readonly axios: AxiosInstance, private readonly featureManager: FeatureManager) {}
+  /**
+   * @param axios The App API client.
+   * @param enabled Whether the price-quote feature is on. Defaults to the hard-coded {@link renderPriceQuotesEnabled}
+   *   flag; injectable so tests can exercise both the on and off paths.
+   */
+  public constructor(private readonly axios: AxiosInstance, private readonly enabled: boolean = renderPriceQuotesEnabled) {}
 
-  /** Whether the price-quote feature is enabled for the current user. */
+  /** Whether the price-quote feature is enabled. */
   public get isEnabled(): boolean {
-    return this.featureManager.isEnabled(FeatureFlags.RenderPriceQuotes)
+    return this.enabled
   }
 
   /** Whether the currently held quote should be treated as stale. */

--- a/packages/web-app/src/modules/render/RenderStore.tsx
+++ b/packages/web-app/src/modules/render/RenderStore.tsx
@@ -1,0 +1,97 @@
+import type { AxiosInstance, AxiosResponse } from 'axios'
+import { action, flow, observable } from 'mobx'
+import type { FeatureManager } from '../../FeatureManager'
+import { FeatureFlags } from '../../FeatureManager'
+import { renderExchangeRateEndpointPath, renderExchangeRateRefreshRate } from './constants'
+import type { RenderExchangeRate, RenderExchangeRateResource } from './models'
+import { isExchangeRateStale, renderExchangeRateFromResource } from './utils'
+
+/**
+ * Owns the live RENDER/USD price quote that powers the price-quote feature.
+ *
+ * All fetching is gated behind the {@link FeatureFlags.RenderPriceQuotes} flag: when the flag is off the store never
+ * touches the network and `exchangeRate` stays `undefined`.
+ */
+export class RenderStore {
+  @observable
+  public exchangeRate?: RenderExchangeRate = undefined
+
+  @observable
+  public isLoadingExchangeRate: boolean = false
+
+  @observable
+  public hasExchangeRateError: boolean = false
+
+  private pollingHandle?: ReturnType<typeof setInterval>
+  private activeViewers: number = 0
+
+  public constructor(private readonly axios: AxiosInstance, private readonly featureManager: FeatureManager) {}
+
+  /** Whether the price-quote feature is enabled for the current user. */
+  public get isEnabled(): boolean {
+    return this.featureManager.isEnabled(FeatureFlags.RenderPriceQuotes)
+  }
+
+  /** Whether the currently held quote should be treated as stale. */
+  public get isExchangeRateStale(): boolean {
+    return isExchangeRateStale(this.exchangeRate)
+  }
+
+  /**
+   * Registers a RENDER reward view as active and begins polling for fresh quotes.
+   *
+   * Reference-counted so multiple simultaneous views (e.g. reward detail and checkout) share a single poll loop.
+   * Returns a no-op when the feature flag is disabled so callers never trigger network activity while dark.
+   */
+  @action.bound
+  public startPollingExchangeRate(): void {
+    if (!this.isEnabled) {
+      return
+    }
+
+    this.activeViewers += 1
+
+    if (this.pollingHandle !== undefined) {
+      return
+    }
+
+    this.fetchExchangeRate()
+    this.pollingHandle = setInterval(() => {
+      this.fetchExchangeRate()
+    }, renderExchangeRateRefreshRate)
+  }
+
+  /** De-registers a RENDER reward view and stops polling once no views remain active. */
+  @action.bound
+  public stopPollingExchangeRate(): void {
+    if (this.activeViewers > 0) {
+      this.activeViewers -= 1
+    }
+
+    if (this.activeViewers === 0 && this.pollingHandle !== undefined) {
+      clearInterval(this.pollingHandle)
+      this.pollingHandle = undefined
+    }
+  }
+
+  /** Fetches the current RENDER/USD quote. No-ops while the feature flag is disabled. */
+  @action.bound
+  public fetchExchangeRate = flow(function* (this: RenderStore) {
+    if (!this.isEnabled) {
+      return
+    }
+
+    this.isLoadingExchangeRate = true
+    this.hasExchangeRateError = false
+
+    try {
+      const response: AxiosResponse<RenderExchangeRateResource> = yield this.axios.get(renderExchangeRateEndpointPath)
+      this.exchangeRate = renderExchangeRateFromResource(response.data, new Date())
+    } catch (error) {
+      this.hasExchangeRateError = true
+      console.error('RenderStore -> fetchExchangeRate: ', error)
+    } finally {
+      this.isLoadingExchangeRate = false
+    }
+  })
+}

--- a/packages/web-app/src/modules/render/constants.tsx
+++ b/packages/web-app/src/modules/render/constants.tsx
@@ -1,0 +1,23 @@
+/** The App API endpoint that returns the current RENDER/USD price quote. */
+export const renderExchangeRateEndpointPath = '/api/v2/render/exchange-rate'
+
+/**
+ * How frequently (in milliseconds) the RENDER price quote is refreshed while a RENDER reward view is active.
+ * Quotes are time-sensitive, so we poll often enough to keep the displayed quote reasonably fresh.
+ */
+export const renderExchangeRateRefreshRate = 30 * 1000
+
+/**
+ * Fallback time-to-live (in milliseconds) used to determine staleness when the API response does not include an
+ * explicit `expiresAt`. After this window has elapsed since the quote's `asOf` time, the quote is considered stale.
+ */
+export const renderExchangeRateDefaultTtl = 60 * 1000
+
+/**
+ * The number of fractional digits shown for a RENDER token quote. RENDER supports more on-chain precision than is
+ * useful to display, so quotes are rounded for presentation.
+ */
+export const renderQuoteDisplayDecimals = 4
+
+/** The tag used to identify a reward that pays out RENDER tokens. */
+export const renderRewardTag = 'render'

--- a/packages/web-app/src/modules/render/constants.tsx
+++ b/packages/web-app/src/modules/render/constants.tsx
@@ -1,4 +1,19 @@
-/** The App API endpoint that returns the current RENDER/USD price quote. */
+/**
+ * Internal, hard-coded feature flag that gates the entire RENDER price-quote feature.
+ *
+ * This is intentionally a compile-time constant rather than a remote/third-party flag (e.g. Unleash): the feature
+ * ships dark while this is `false` — no quote UI is rendered and no calls are made to the exchange-rate endpoint.
+ * Flip it to `true` and redeploy to turn the feature on.
+ */
+export const renderPriceQuotesEnabled = false
+
+/**
+ * The App API endpoint that returns the current RENDER/USD price quote.
+ *
+ * This endpoint is the single source of truth for the RENDER price: the rate is computed server-side and the web app
+ * never performs its own price discovery (no on-chain / Jupiter calls happen client-side). The only client-side math
+ * is converting a USD Salad Balance into a token amount via {@link computeRenderQuote}.
+ */
 export const renderExchangeRateEndpointPath = '/api/v2/render/exchange-rate'
 
 /**

--- a/packages/web-app/src/modules/render/index.tsx
+++ b/packages/web-app/src/modules/render/index.tsx
@@ -1,0 +1,4 @@
+export * from './RenderStore'
+export * from './constants'
+export * from './models'
+export * from './utils'

--- a/packages/web-app/src/modules/render/models/RenderExchangeRate.tsx
+++ b/packages/web-app/src/modules/render/models/RenderExchangeRate.tsx
@@ -1,0 +1,11 @@
+/** A time-sensitive RENDER/USD price quote returned by the App API. */
+export interface RenderExchangeRate {
+  /** The current price of a single RENDER token, expressed in USD. */
+  rate: number
+
+  /** When the quote was generated. */
+  asOf: Date
+
+  /** When the quote should be considered stale. May be absent if the API does not provide an explicit expiry. */
+  expiresAt?: Date
+}

--- a/packages/web-app/src/modules/render/models/RenderExchangeRateResource.tsx
+++ b/packages/web-app/src/modules/render/models/RenderExchangeRateResource.tsx
@@ -1,0 +1,11 @@
+/** The raw shape of the `GET /api/v2/render/exchange-rate` response. */
+export interface RenderExchangeRateResource {
+  /** The current price of a single RENDER token, expressed in USD. */
+  rate: number
+
+  /** ISO-8601 timestamp for when the quote was generated. */
+  asOf?: string
+
+  /** ISO-8601 timestamp for when the quote should be considered stale. */
+  expiresAt?: string
+}

--- a/packages/web-app/src/modules/render/models/index.tsx
+++ b/packages/web-app/src/modules/render/models/index.tsx
@@ -1,0 +1,2 @@
+export * from './RenderExchangeRate'
+export * from './RenderExchangeRateResource'

--- a/packages/web-app/src/modules/render/utils.test.ts
+++ b/packages/web-app/src/modules/render/utils.test.ts
@@ -1,0 +1,104 @@
+import type { Reward } from '../reward/models'
+import { renderExchangeRateDefaultTtl } from './constants'
+import type { RenderExchangeRate } from './models'
+import {
+  computeRenderQuote,
+  isExchangeRateStale,
+  isRenderReward,
+  renderExchangeRateFromResource,
+} from './utils'
+
+describe('computeRenderQuote', () => {
+  it('converts a USD balance into RENDER tokens at the given rate', () => {
+    // $10 of balance at $2.50 / RENDER = 4 RENDER
+    expect(computeRenderQuote(10, 2.5)).toBe(4)
+  })
+
+  it('rounds to the requested number of decimals', () => {
+    // 1 / 3 = 0.3333... -> 0.3333 at the default (4) precision
+    expect(computeRenderQuote(1, 3)).toBe(0.3333)
+    expect(computeRenderQuote(1, 3, 2)).toBe(0.33)
+    expect(computeRenderQuote(1, 3, 8)).toBe(0.33333333)
+  })
+
+  it('returns 0 for a zero balance', () => {
+    expect(computeRenderQuote(0, 2.5)).toBe(0)
+  })
+
+  it('handles large values without losing the integer part', () => {
+    expect(computeRenderQuote(1_000_000, 0.5)).toBe(2_000_000)
+  })
+
+  it('returns undefined when the rate is zero or negative', () => {
+    expect(computeRenderQuote(10, 0)).toBeUndefined()
+    expect(computeRenderQuote(10, -1)).toBeUndefined()
+  })
+
+  it('returns undefined for non-finite or negative inputs', () => {
+    expect(computeRenderQuote(NaN, 2)).toBeUndefined()
+    expect(computeRenderQuote(10, NaN)).toBeUndefined()
+    expect(computeRenderQuote(Infinity, 2)).toBeUndefined()
+    expect(computeRenderQuote(-5, 2)).toBeUndefined()
+  })
+})
+
+describe('isRenderReward', () => {
+  const makeReward = (tags: string[]): Reward => ({ id: '1', name: 'r', price: 5, tags })
+
+  it('returns true when the reward carries the render tag', () => {
+    expect(isRenderReward(makeReward(['render', 'crypto']))).toBe(true)
+  })
+
+  it('returns false when the reward has no render tag', () => {
+    expect(isRenderReward(makeReward(['steam']))).toBe(false)
+  })
+
+  it('returns false for an undefined reward', () => {
+    expect(isRenderReward(undefined)).toBe(false)
+  })
+})
+
+describe('renderExchangeRateFromResource', () => {
+  it('maps the API resource and parses timestamps', () => {
+    const receivedAt = new Date('2026-06-24T00:00:30.000Z')
+    const result = renderExchangeRateFromResource(
+      { rate: 2.5, asOf: '2026-06-24T00:00:00.000Z', expiresAt: '2026-06-24T00:01:00.000Z' },
+      receivedAt,
+    )
+
+    expect(result.rate).toBe(2.5)
+    expect(result.asOf.toISOString()).toBe('2026-06-24T00:00:00.000Z')
+    expect(result.expiresAt?.toISOString()).toBe('2026-06-24T00:01:00.000Z')
+  })
+
+  it('falls back to receivedAt when asOf is missing', () => {
+    const receivedAt = new Date('2026-06-24T00:00:30.000Z')
+    const result = renderExchangeRateFromResource({ rate: 2.5 }, receivedAt)
+
+    expect(result.asOf).toBe(receivedAt)
+    expect(result.expiresAt).toBeUndefined()
+  })
+})
+
+describe('isExchangeRateStale', () => {
+  const asOf = new Date('2026-06-24T00:00:00.000Z')
+
+  it('returns false when no quote is present', () => {
+    expect(isExchangeRateStale(undefined)).toBe(false)
+  })
+
+  it('uses expiresAt when available', () => {
+    const rate: RenderExchangeRate = { rate: 2.5, asOf, expiresAt: new Date('2026-06-24T00:01:00.000Z') }
+    expect(isExchangeRateStale(rate, new Date('2026-06-24T00:00:59.000Z'))).toBe(false)
+    expect(isExchangeRateStale(rate, new Date('2026-06-24T00:01:00.000Z'))).toBe(true)
+  })
+
+  it('falls back to the default TTL when expiresAt is absent', () => {
+    const rate: RenderExchangeRate = { rate: 2.5, asOf }
+    const justBefore = new Date(asOf.getTime() + renderExchangeRateDefaultTtl - 1)
+    const atTtl = new Date(asOf.getTime() + renderExchangeRateDefaultTtl)
+
+    expect(isExchangeRateStale(rate, justBefore)).toBe(false)
+    expect(isExchangeRateStale(rate, atTtl)).toBe(true)
+  })
+})

--- a/packages/web-app/src/modules/render/utils.tsx
+++ b/packages/web-app/src/modules/render/utils.tsx
@@ -1,0 +1,67 @@
+import type { Reward } from '../reward/models'
+import { renderExchangeRateDefaultTtl, renderQuoteDisplayDecimals, renderRewardTag } from './constants'
+import type { RenderExchangeRate, RenderExchangeRateResource } from './models'
+
+/**
+ * Determines whether a reward pays out RENDER tokens.
+ *
+ * Reward tags are lower-cased when a reward is parsed from its API resource, so a case-insensitive match is not
+ * required here.
+ */
+export const isRenderReward = (reward?: Reward): boolean => !!reward?.tags?.includes(renderRewardTag)
+
+/**
+ * Converts a `GET /api/v2/render/exchange-rate` response into the internal {@link RenderExchangeRate} model.
+ *
+ * When the API omits `asOf`, the provided `receivedAt` time is used so that staleness can still be tracked.
+ */
+export const renderExchangeRateFromResource = (
+  resource: RenderExchangeRateResource,
+  receivedAt: Date,
+): RenderExchangeRate => ({
+  rate: resource.rate,
+  asOf: resource.asOf ? new Date(resource.asOf) : receivedAt,
+  expiresAt: resource.expiresAt ? new Date(resource.expiresAt) : undefined,
+})
+
+/**
+ * Computes how many RENDER tokens a given amount of Salad Balance (USD) converts to at the supplied price.
+ *
+ * @param saladBalance The amount of Salad Balance to convert, in USD.
+ * @param rate The price of a single RENDER token, in USD.
+ * @param decimals The number of fractional digits to round the result to. Defaults to the display precision.
+ * @returns The number of RENDER tokens, or `undefined` when the inputs cannot produce a meaningful quote.
+ */
+export const computeRenderQuote = (
+  saladBalance: number,
+  rate: number,
+  decimals: number = renderQuoteDisplayDecimals,
+): number | undefined => {
+  if (!Number.isFinite(saladBalance) || !Number.isFinite(rate) || rate <= 0 || saladBalance < 0) {
+    return undefined
+  }
+
+  const tokens = saladBalance / rate
+  const factor = Math.pow(10, decimals)
+
+  // Math.round can drift on values such as 1.005; normalize through a string round-trip to keep precision predictable.
+  return Math.round((tokens + Number.EPSILON) * factor) / factor
+}
+
+/**
+ * Determines whether a quote is stale relative to `now`.
+ *
+ * A quote is stale once its `expiresAt` has passed. When no explicit expiry is provided, a quote is considered stale
+ * after {@link renderExchangeRateDefaultTtl} has elapsed since its `asOf` time.
+ */
+export const isExchangeRateStale = (rate: RenderExchangeRate | undefined, now: Date = new Date()): boolean => {
+  if (!rate) {
+    return false
+  }
+
+  if (rate.expiresAt) {
+    return now.getTime() >= rate.expiresAt.getTime()
+  }
+
+  return now.getTime() - rate.asOf.getTime() >= renderExchangeRateDefaultTtl
+}

--- a/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuote.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuote.tsx
@@ -1,0 +1,121 @@
+import { DateTime } from 'luxon'
+import type { FC } from 'react'
+import Skeleton from 'react-loading-skeleton'
+import type { WithStyles } from 'react-jss'
+import withStyles from 'react-jss'
+import type { SaladTheme } from '../../../../SaladTheme'
+import { renderQuoteDisplayDecimals } from '../../../render'
+
+const styles = (theme: SaladTheme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+  },
+  containerCheckout: {
+    alignItems: 'flex-start',
+  },
+  amountText: {
+    color: theme.green,
+    fontFamily: theme.fontGroteskLight09,
+    fontSize: 18,
+    letterSpacing: 0.5,
+  },
+  freshnessText: {
+    fontFamily: theme.fontGroteskBook25,
+    fontSize: 8,
+    letterSpacing: 1,
+    color: theme.green,
+    opacity: 0.7,
+    textTransform: 'uppercase',
+  },
+  staleText: {
+    color: theme.orange,
+    opacity: 1,
+  },
+  errorText: {
+    fontFamily: theme.fontGroteskBook25,
+    fontSize: 10,
+    letterSpacing: 1,
+    color: theme.green,
+    opacity: 0.7,
+  },
+  skeleton: {
+    width: 90,
+  },
+})
+
+const renderTokenFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: renderQuoteDisplayDecimals,
+})
+
+export interface RenderPriceQuoteProps extends WithStyles<typeof styles> {
+  /** Whether a quote request is currently in flight and no quote is available yet. */
+  loading?: boolean
+  /** Whether the most recent quote request failed. */
+  error?: boolean
+  /** Whether the currently displayed quote is stale. */
+  stale?: boolean
+  /** The number of RENDER tokens the reward's Salad Balance value converts to. */
+  tokenAmount?: number
+  /** When the displayed quote was generated. */
+  asOf?: Date
+  /** Controls layout/labelling for the detail header vs. the checkout review surface. */
+  variant?: 'detail' | 'checkout'
+}
+
+const _RenderPriceQuote: FC<RenderPriceQuoteProps> = ({
+  classes,
+  loading,
+  error,
+  stale,
+  tokenAmount,
+  asOf,
+  variant = 'detail',
+}) => {
+  const containerClass =
+    variant === 'checkout' ? `${classes.container} ${classes.containerCheckout}` : classes.container
+
+  if (loading && tokenAmount === undefined) {
+    return (
+      <div className={containerClass}>
+        <div className={classes.skeleton}>
+          <Skeleton />
+        </div>
+      </div>
+    )
+  }
+
+  if (error && tokenAmount === undefined) {
+    return (
+      <div className={containerClass}>
+        <div className={classes.errorText}>RENDER price unavailable</div>
+      </div>
+    )
+  }
+
+  if (tokenAmount === undefined) {
+    return null
+  }
+
+  const asOfLabel = asOf ? DateTime.fromJSDate(asOf).toRelative() : undefined
+  const freshnessText = stale
+    ? 'Price may be out of date'
+    : asOfLabel
+    ? `Quoted ${asOfLabel}`
+    : undefined
+
+  return (
+    <div className={containerClass}>
+      <div className={classes.amountText}>≈ {renderTokenFormatter.format(tokenAmount)} RENDER</div>
+      {freshnessText && (
+        <div className={stale ? `${classes.freshnessText} ${classes.staleText}` : classes.freshnessText}>
+          {freshnessText}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const RenderPriceQuote = withStyles(styles)(_RenderPriceQuote)

--- a/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
@@ -1,9 +1,8 @@
 import { observer } from 'mobx-react'
 import type { FC } from 'react'
 import { useEffect } from 'react'
-import { FeatureFlags, useFeatureManager } from '../../../../FeatureManager'
 import { getStore } from '../../../../Store'
-import { computeRenderQuote, isRenderReward } from '../../../render'
+import { computeRenderQuote, isRenderReward, renderPriceQuotesEnabled } from '../../../render'
 import type { Reward } from '../../../reward/models'
 import { RenderPriceQuote } from './RenderPriceQuote'
 
@@ -19,13 +18,11 @@ export interface RenderPriceQuoteContainerProps {
 /**
  * Surfaces a live RENDER price quote for a reward.
  *
- * Renders nothing — and triggers no network activity — unless the {@link FeatureFlags.RenderPriceQuotes} flag is on
- * and the reward is a RENDER reward. While active it keeps the quote fresh via the {@link RenderStore} poll loop.
+ * Renders nothing — and triggers no network activity — unless the internal {@link renderPriceQuotesEnabled} flag is
+ * on and the reward is a RENDER reward. While active it keeps the quote fresh via the {@link RenderStore} poll loop.
  */
 const _RenderPriceQuoteContainer: FC<RenderPriceQuoteContainerProps> = ({ reward, saladBalance, variant }) => {
-  const featureManager = useFeatureManager()
-  const enabled = featureManager.isEnabled(FeatureFlags.RenderPriceQuotes)
-  const active = enabled && isRenderReward(reward)
+  const active = renderPriceQuotesEnabled && isRenderReward(reward)
   const store = getStore()
   const render = store.render
 

--- a/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
@@ -1,0 +1,67 @@
+import { observer } from 'mobx-react'
+import type { FC } from 'react'
+import { useEffect } from 'react'
+import { FeatureFlags, useFeatureManager } from '../../../../FeatureManager'
+import { getStore } from '../../../../Store'
+import { computeRenderQuote, isRenderReward } from '../../../render'
+import type { Reward } from '../../../reward/models'
+import { RenderPriceQuote } from './RenderPriceQuote'
+
+export interface RenderPriceQuoteContainerProps {
+  /** The RENDER reward the quote is being shown for. */
+  reward?: Reward
+  /** The Salad Balance amount (USD) to convert into RENDER tokens. Defaults to the reward's price. */
+  saladBalance?: number
+  /** Controls layout/labelling for the detail header vs. the checkout review surface. */
+  variant?: 'detail' | 'checkout'
+}
+
+/**
+ * Surfaces a live RENDER price quote for a reward.
+ *
+ * Renders nothing — and triggers no network activity — unless the {@link FeatureFlags.RenderPriceQuotes} flag is on
+ * and the reward is a RENDER reward. While active it keeps the quote fresh via the {@link RenderStore} poll loop.
+ */
+const _RenderPriceQuoteContainer: FC<RenderPriceQuoteContainerProps> = ({ reward, saladBalance, variant }) => {
+  const featureManager = useFeatureManager()
+  const enabled = featureManager.isEnabled(FeatureFlags.RenderPriceQuotes)
+  const active = enabled && isRenderReward(reward)
+  const store = getStore()
+  const render = store.render
+
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+    render.startPollingExchangeRate()
+    return () => render.stopPollingExchangeRate()
+  }, [active, render])
+
+  const amount = saladBalance ?? reward?.price ?? 0
+  const tokenAmount = render.exchangeRate ? computeRenderQuote(amount, render.exchangeRate.rate) : undefined
+
+  useEffect(() => {
+    if (active && reward && tokenAmount !== undefined) {
+      store.analytics.trackRenderPriceQuoteViewed(reward, tokenAmount, render.exchangeRate?.rate)
+    }
+    // Fire once per reward + quote pairing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, reward?.id, tokenAmount])
+
+  if (!active) {
+    return null
+  }
+
+  return (
+    <RenderPriceQuote
+      loading={render.isLoadingExchangeRate}
+      error={render.hasExchangeRateError}
+      stale={render.isExchangeRateStale}
+      tokenAmount={tokenAmount}
+      asOf={render.exchangeRate?.asOf}
+      variant={variant}
+    />
+  )
+}
+
+export const RenderPriceQuoteContainer = observer(_RenderPriceQuoteContainer)

--- a/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/index.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/index.tsx
@@ -1,0 +1,2 @@
+export * from './RenderPriceQuote'
+export * from './RenderPriceQuoteContainer'

--- a/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
@@ -8,6 +8,7 @@ import type { SaladTheme } from '../../../SaladTheme'
 import type { Reward } from '../../reward/models'
 import { getPercentOff } from '../../reward/utils'
 import { IconArrowLeft } from './assets'
+import { RenderPriceQuoteContainer } from './RenderPriceQuote'
 
 const styles = (theme: SaladTheme) => ({
   container: {
@@ -241,6 +242,7 @@ class _RewardHeaderBar extends Component<Props> {
                   <SmartLink to="/account/summary">Add Minecraft Username</SmartLink>
                 </div>
               )}
+              <RenderPriceQuoteContainer reward={reward} variant="detail" />
             </div>
             {getTargetRewardControl()}
             <Button

--- a/packages/web-app/src/modules/reward-views/components/index.tsx
+++ b/packages/web-app/src/modules/reward-views/components/index.tsx
@@ -1,4 +1,5 @@
 export * from '../../storefront-views/pages/StorefrontHomePage/RewardSearchBar/RewardSearchBar'
+export * from './RenderPriceQuote'
 export * from './RewardDescriptionPanel'
 export * from './RewardDisclaimers'
 export * from './RewardHeaderBar'

--- a/packages/web-app/src/modules/salad-pay-views/SaladPayOrderSummaryContainer.tsx
+++ b/packages/web-app/src/modules/salad-pay-views/SaladPayOrderSummaryContainer.tsx
@@ -1,3 +1,4 @@
+import { getStore } from '../../Store'
 import type { SaladPayStore } from '../salad-pay/SaladPayStore'
 import { SaladPayOrderSummaryPage } from './components'
 import { connectSaladPay } from './connectSaladPay'
@@ -6,6 +7,7 @@ const mapStoreToProps = (store: SaladPayStore): any => ({
   availableBalance: store.currentBalance,
   processing: store.processing,
   request: store.currentRequestOptions,
+  reward: getStore().rewards.getReward(getStore().rewards.lastRewardId),
   onClose: () => {
     store.abort()
     store.goBackToReward()

--- a/packages/web-app/src/modules/salad-pay-views/components/SaladPayOrderSummaryPage.tsx
+++ b/packages/web-app/src/modules/salad-pay-views/components/SaladPayOrderSummaryPage.tsx
@@ -7,6 +7,8 @@ import { SaladPayPage } from '.'
 import type { SaladTheme } from '../../../SaladTheme'
 import { SmartLink } from '../../../components'
 import { currencyFormatter } from '../../../formatters'
+import { RenderPriceQuoteContainer } from '../../reward-views/components/RenderPriceQuote'
+import type { Reward } from '../../reward/models'
 import type { SaladPaymentRequestOptions } from '../../salad-pay/models'
 import { SaladPayCheckoutButton } from './SaladPayCheckoutButton'
 
@@ -78,6 +80,7 @@ interface Props extends WithStyles<typeof styles> {
   availableBalance?: number
   processing?: boolean
   request?: SaladPaymentRequestOptions
+  reward?: Reward
   onConfirm: () => void
   onCloseClick: () => void
   onAbort: () => void
@@ -90,6 +93,7 @@ const _SaladPayOrderSummaryPage: FC<Props> = ({
   availableBalance,
   processing,
   request,
+  reward,
   onConfirm,
   onCloseClick,
   onAbort,
@@ -136,6 +140,7 @@ const _SaladPayOrderSummaryPage: FC<Props> = ({
               <div className={classes.leftText}>{request.total.label}</div>
               <div>{moneyFormat(request.total.amount)}</div>
             </div>
+            <RenderPriceQuoteContainer reward={reward} saladBalance={request.total.amount} variant="checkout" />
             <div className={classNames(classes.row, classes.balanceRow)}>
               <div className={classes.leftText}>
                 <div className={classes.title}>Available Balance</div>

--- a/packages/web-app/tsconfig.json
+++ b/packages/web-app/tsconfig.json
@@ -27,5 +27,5 @@
     "target": "es5"
   },
   "include": ["src"],
-  "exclude": ["**/*.stories.ts", "**/*.stories.tsx"]
+  "exclude": ["**/*.stories.ts", "**/*.stories.tsx", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Goal
Surface live RENDER price quotes to Chefs while they browse and check out RENDER rewards in the `salad-applications` web app. The entire feature must sit behind a feature flag so it can be shipped dark and toggled on later.

## Backend dependency (consumed, not built here)
This task consumes the public exchange-rate endpoint defined in the project brief:
- `GET /api/v2/render/exchange-rate` → current RENDER/USD price.

The web app will call this to compute how many RENDER tokens a given Salad Balance amount converts to. Treat the response as time-sensitive (quotes go stale), so capture the quote timestamp/expiry alongside the rate.

## Feature flag
- Add a flag, e.g. `render-price-quotes` (follow the existing feature-flag mechanism in the repo — LaunchDarkly/config/env, whichever this codebase already uses). Do NOT invent a new flag system.
- Gate all new UI (quote display on reward detail + checkout) behind this flag. When off, reward views render exactly as today with no quote and no network calls to the exchange-rate endpoint.

## Data layer
1. Add an API client function `getRenderExchangeRate()` that calls `GET /api/v2/render/exchange-rate` and returns `{ rate, asOf/expiresAt }`.
2. Add a typed model for the exchange-rate response.
3. Add a hook/store selector (matching the repo's data-fetching pattern — React Query / Redux / Recoil etc.) that:
   - Fetches the rate only when the flag is on and a RENDER reward view is active.
   - Polls or refetches so the quote stays reasonably fresh.
   - Exposes loading / error / stale states.
4. Add a pure helper `computeRenderQuote(saladBalance, rate)` → token amount, with appropriate rounding/precision for RENDER decimals. Keep it unit-testable.

## UI
1. On the RENDER reward detail / storefront view: show "≈ X RENDER" for the reward's Salad Balance value, plus a freshness indicator.
2. On the checkout/redemption review step: show the quoted RENDER amount the Chef will receive and the quote's as-of time. (Full stale-quote abort UX is a separate task; here just display the quote and its freshness so that flow can build on it.)
3. Handle states: loading (skeleton/spinner), error (graceful fallback — hide quote or show "price unavailable"), and stale (visual hint).
4. Localize all new strings via the existing i18n setup.

## Telemetry (light)
- Fire a Mixpanel event when a price quote is viewed, if the repo already wires Mixpanel into reward views (reward managers want redemption tracking). Keep it minimal and behind the same flag.

## Testing
- Unit tests for `computeRenderQuote` (rounding, zero, large values).
- Tests for the hook: flag-off → no fetch; flag-on → fetch + state transitions.
- Component tests for loading/error/stale rendering.

## Notes / conventions
- This repo's Next.js is non-standard — before writing any code, read the relevant guide under `node_modules/next/dist/docs/` per AGENTS.md.
- Match existing patterns for API clients, feature flags, i18n, and state management rather than introducing new libraries.
- No secrets or Jupiter calls happen client-side; the web app only talks to the Salad app API exchange-rate route.