### PR TITLE
[Web App] Catch and show 409 error on payment for RENDER reward

### DIFF
--- a/packages/web-app/src/modules/reward/RewardStore.test.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.test.ts
@@ -23,6 +23,7 @@ import type { RootStore } from '../../Store'
 import type { NotificationMessage } from '../notifications/models'
 import { NotificationMessageCategory } from '../notifications/models'
 import type { ProfileStore } from '../profile'
+import { solanaWalletAccountAnchor } from '../solana-wallet'
 import type { Reward } from './models/Reward'
 import {
   RewardStore,
@@ -92,15 +93,19 @@ const setup = (postImpl: jest.Mock): Harness => {
 }
 
 describe('RewardStore.redeemReward 400 redemptions:requires:* handling', () => {
-  it.each([
-    ['renderTokenAccount', renderTokenAccountRequiredProblemType],
-    ['solanaWallet', solanaWalletRequiredProblemType],
-  ])('surfaces the API message and returns to the reward detail page for %s', async (_label, type) => {
-    const apiTitle = 'Uh-oh! We could not complete your redemption.'
-    const apiDetail = 'The account is missing a prerequisite for this reward.'
+  it('surfaces the API message and returns to the reward detail page for renderTokenAccount', async () => {
+    const apiTitle = 'RENDER associated token account required'
+    const apiDetail = 'The account is missing a RENDER associated token account.'
     const post = jest
       .fn()
-      .mockRejectedValue(makeAxiosError(400, { type, status: 400, title: apiTitle, detail: apiDetail }))
+      .mockRejectedValue(
+        makeAxiosError(400, {
+          type: renderTokenAccountRequiredProblemType,
+          status: 400,
+          title: apiTitle,
+          detail: apiDetail,
+        }),
+      )
     const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post)
     const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens' })
 
@@ -118,8 +123,82 @@ describe('RewardStore.redeemReward 400 redemptions:requires:* handling', () => {
     expect(notification.title).toBe(apiTitle)
     expect(notification.message).toBe(apiDetail)
 
+    // The notification's onClick returns the user to the reward detail page.
+    notification.onClick?.()
+    expect(push).toHaveBeenCalledWith('/rewards/render-1')
+
     // User is sent back to the reward detail page.
     expect(push).toHaveBeenCalledWith('/rewards/render-1')
+  })
+
+  it('falls back to a RENDER-specific title when the API omits the title for renderTokenAccount', async () => {
+    const apiDetail = 'The account is missing a RENDER associated token account.'
+    const post = jest
+      .fn()
+      .mockRejectedValue(
+        makeAxiosError(400, { type: renderTokenAccountRequiredProblemType, status: 400, detail: apiDetail }),
+      )
+    const { store, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens' })
+
+    await store.redeemReward(reward)
+
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.title).toBe('RENDER token account required')
+    expect(notification.title).not.toBe('Uh-oh! We could not complete your redemption.')
+  })
+
+  it('surfaces the API message and points the user to the wallet input for solanaWallet', async () => {
+    const apiTitle = 'Solana wallet address required'
+    const apiDetail = 'The account has no configured Solana wallet.'
+    const post = jest
+      .fn()
+      .mockRejectedValue(
+        makeAxiosError(400, {
+          type: solanaWalletRequiredProblemType,
+          status: 400,
+          title: apiTitle,
+          detail: apiDetail,
+        }),
+      )
+    const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post)
+    const reward = makeReward({ id: 'solana-1', name: 'RENDER Tokens' })
+
+    await store.redeemReward(reward)
+
+    // Success side effects must not fire.
+    expect(addRewardToRedemptionsList).not.toHaveBeenCalled()
+    expect(store.isReviewing).toBe(false)
+
+    // Error notification carries the message from the API response.
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.category).toBe(NotificationMessageCategory.Error)
+    expect(notification.type).toBe('error')
+    expect(notification.title).toBe(apiTitle)
+    expect(notification.message).toBe(apiDetail)
+
+    // The notification's onClick navigates to the account page's Solana wallet address input.
+    notification.onClick?.()
+    expect(push).toHaveBeenCalledWith(solanaWalletAccountAnchor)
+
+    // User is sent back to the reward detail page.
+    expect(push).toHaveBeenCalledWith('/rewards/solana-1')
+  })
+
+  it('falls back to a Solana-specific title when the API omits the title for solanaWallet', async () => {
+    const apiDetail = 'The account has no configured Solana wallet.'
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type: solanaWalletRequiredProblemType, status: 400, detail: apiDetail }))
+    const { store, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'solana-1', name: 'RENDER Tokens' })
+
+    await store.redeemReward(reward)
+
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.title).toBe('Solana wallet required')
+    expect(notification.title).not.toBe('Uh-oh! We could not complete your redemption.')
   })
 
   it('applies the existing 400 handling (no navigation) for an unrelated problem code', async () => {

--- a/packages/web-app/src/modules/reward/RewardStore.test.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.test.ts
@@ -1,7 +1,6 @@
 /**
  * These mocks keep the test from pulling in the full RootStore dependency graph (and ESM-only
- * packages such as `axios`/`query-string`) that `RewardStore`'s transitive imports would otherwise
- * load. The real `../render` module is intentionally NOT mocked so `isRenderReward` is exercised for real.
+ * packages such as `axios`/`query-string`) that `RewardStore`'s transitive imports would otherwise load.
  */
 jest.mock('axios', () => ({
   __esModule: true,
@@ -24,15 +23,18 @@ import type { RootStore } from '../../Store'
 import type { NotificationMessage } from '../notifications/models'
 import { NotificationMessageCategory } from '../notifications/models'
 import type { ProfileStore } from '../profile'
-import { renderRewardTag } from '../render'
 import type { Reward } from './models/Reward'
-import { RewardStore } from './RewardStore'
+import {
+  RewardStore,
+  renderTokenAccountRequiredProblemType,
+  solanaWalletRequiredProblemType,
+} from './RewardStore'
 
 /** Builds a minimal axios-style error that the mocked `Axios.isAxiosError` recognizes. */
-const makeAxiosError = (status: number) => ({
+const makeAxiosError = (status: number, data: unknown = {}) => ({
   isAxiosError: true,
   message: `Request failed with status code ${status}`,
-  response: { status, data: {} },
+  response: { status, data },
 })
 
 const makeReward = (overrides: Partial<Reward> = {}): Reward => ({
@@ -89,11 +91,18 @@ const setup = (postImpl: jest.Mock): Harness => {
   return { store, push, sendNotification, addRewardToRedemptionsList, complete }
 }
 
-describe('RewardStore.redeemReward 409 handling', () => {
-  it('treats a 409 on a RENDER reward as an error and returns to the reward detail page', async () => {
-    const post = jest.fn().mockRejectedValue(makeAxiosError(409))
+describe('RewardStore.redeemReward 400 redemptions:requires:* handling', () => {
+  it.each([
+    ['renderTokenAccount', renderTokenAccountRequiredProblemType],
+    ['solanaWallet', solanaWalletRequiredProblemType],
+  ])('surfaces the API message and returns to the reward detail page for %s', async (_label, type) => {
+    const apiTitle = 'Uh-oh! We could not complete your redemption.'
+    const apiDetail = 'The account is missing a prerequisite for this reward.'
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type, status: 400, title: apiTitle, detail: apiDetail }))
     const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post)
-    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: [renderRewardTag] })
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens' })
 
     await store.redeemReward(reward)
 
@@ -101,18 +110,38 @@ describe('RewardStore.redeemReward 409 handling', () => {
     expect(addRewardToRedemptionsList).not.toHaveBeenCalled()
     expect(store.isReviewing).toBe(false)
 
-    // Error notification with the exact copy.
+    // Error notification carries the message from the API response.
     expect(sendNotification).toHaveBeenCalledTimes(1)
     const notification = sendNotification.mock.calls[0][0] as NotificationMessage
     expect(notification.category).toBe(NotificationMessageCategory.Error)
     expect(notification.type).toBe('error')
-    expect(notification.message).toBe('No RENDER associated token account found for wallet you have provided')
+    expect(notification.title).toBe(apiTitle)
+    expect(notification.message).toBe(apiDetail)
 
     // User is sent back to the reward detail page.
     expect(push).toHaveBeenCalledWith('/rewards/render-1')
   })
 
-  it('treats a 409 on a non-RENDER reward as the existing redemption success message', async () => {
+  it('applies the existing 400 handling (no navigation) for an unrelated problem code', async () => {
+    const post = jest
+      .fn()
+      .mockRejectedValue(
+        makeAxiosError(400, { type: 'redemptions:notEnoughXp', status: 400, title: 'Nope', detail: 'Too new' }),
+      )
+    const { store, push, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'reward-2', name: 'Some Game' })
+
+    await store.redeemReward(reward)
+
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.title).toBe('Redemption Error')
+    expect(push).not.toHaveBeenCalled()
+  })
+})
+
+describe('RewardStore.redeemReward other statuses', () => {
+  it('treats a 409 as the redemption success message (regression guard)', async () => {
     const post = jest.fn().mockRejectedValue(makeAxiosError(409))
     const { store, push, sendNotification } = setup(post)
     const reward = makeReward({ id: 'reward-2', name: 'Some Game' })
@@ -123,19 +152,19 @@ describe('RewardStore.redeemReward 409 handling', () => {
     const notification = sendNotification.mock.calls[0][0] as NotificationMessage
     expect(notification.category).toBe(NotificationMessageCategory.Redemption)
     expect(notification.title).toContain('Thank you for ordering')
-    expect(push).not.toHaveBeenCalledWith('/rewards/reward-2')
+    expect(push).not.toHaveBeenCalled()
   })
 
-  it('does not apply the RENDER 409 handling to other error statuses', async () => {
+  it('does not apply the requires-prerequisite handling to other error statuses', async () => {
     const post = jest.fn().mockRejectedValue(makeAxiosError(500))
     const { store, push, sendNotification } = setup(post)
-    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: [renderRewardTag] })
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens' })
 
     await store.redeemReward(reward)
 
     expect(sendNotification).toHaveBeenCalledTimes(1)
     const notification = sendNotification.mock.calls[0][0] as NotificationMessage
-    expect(notification.message).not.toBe('No RENDER associated token account found for wallet you have provided')
+    expect(notification.category).toBe(NotificationMessageCategory.Error)
     expect(push).not.toHaveBeenCalled()
   })
 })

--- a/packages/web-app/src/modules/reward/RewardStore.test.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.test.ts
@@ -148,6 +148,19 @@ describe('RewardStore.redeemReward 400 redemptions:requires:* handling', () => {
     expect(notification.title).not.toBe('Uh-oh! We could not complete your redemption.')
   })
 
+  it('falls back to a RENDER-specific message when the API omits the detail for renderTokenAccount', async () => {
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type: renderTokenAccountRequiredProblemType, status: 400 }))
+    const { store, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens' })
+
+    await store.redeemReward(reward)
+
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.message).toBe('A render token account is required')
+  })
+
   it('surfaces the API message and points the user to the wallet input for solanaWallet', async () => {
     const apiTitle = 'Solana wallet address required'
     const apiDetail = 'The account has no configured Solana wallet.'
@@ -199,6 +212,19 @@ describe('RewardStore.redeemReward 400 redemptions:requires:* handling', () => {
     const notification = sendNotification.mock.calls[0][0] as NotificationMessage
     expect(notification.title).toBe('Solana wallet required')
     expect(notification.title).not.toBe('Uh-oh! We could not complete your redemption.')
+  })
+
+  it('falls back to a Solana-specific message when the API omits the detail for solanaWallet', async () => {
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type: solanaWalletRequiredProblemType, status: 400 }))
+    const { store, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'solana-1', name: 'RENDER Tokens' })
+
+    await store.redeemReward(reward)
+
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.message).toBe('You need to add a solana wallet in order to purchase this reward')
   })
 
   it('applies the existing 400 handling (no navigation) for an unrelated problem code', async () => {

--- a/packages/web-app/src/modules/reward/RewardStore.test.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.test.ts
@@ -1,0 +1,141 @@
+/**
+ * These mocks keep the test from pulling in the full RootStore dependency graph (and ESM-only
+ * packages such as `axios`/`query-string`) that `RewardStore`'s transitive imports would otherwise
+ * load. The real `../render` module is intentionally NOT mocked so `isRenderReward` is exercised for real.
+ */
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { isAxiosError: (error: any) => !!(error && error.isAxiosError) },
+}))
+jest.mock('../../axiosFactory', () => ({ SaladError: class SaladError extends Error {} }))
+jest.mock('../salad-pay', () => ({ AbortError: class AbortError extends Error {} }))
+jest.mock('../salad-pay/SaladPay', () => ({
+  SaladPay: class SaladPay {
+    paymentRequest() {
+      return { show: async () => ({}) }
+    }
+  },
+}))
+jest.mock('../auth', () => ({ ChallengeSudoModeTrigger: { RewardRedeem: 'RewardRedeem' } }))
+jest.mock('./utils', () => ({ rewardFromResource: jest.fn() }))
+
+import type { AxiosInstance } from 'axios'
+import type { RootStore } from '../../Store'
+import type { NotificationMessage } from '../notifications/models'
+import { NotificationMessageCategory } from '../notifications/models'
+import type { ProfileStore } from '../profile'
+import { renderRewardTag } from '../render'
+import type { Reward } from './models/Reward'
+import { RewardStore } from './RewardStore'
+
+/** Builds a minimal axios-style error that the mocked `Axios.isAxiosError` recognizes. */
+const makeAxiosError = (status: number) => ({
+  isAxiosError: true,
+  message: `Request failed with status code ${status}`,
+  response: { status, data: {} },
+})
+
+const makeReward = (overrides: Partial<Reward> = {}): Reward => ({
+  id: 'reward-1',
+  name: 'Test Reward',
+  price: 10,
+  tags: [],
+  ...overrides,
+})
+
+interface Harness {
+  store: RewardStore
+  push: jest.Mock
+  sendNotification: jest.Mock
+  addRewardToRedemptionsList: jest.Mock
+  complete: jest.Mock
+}
+
+const setup = (postImpl: jest.Mock): Harness => {
+  const push = jest.fn()
+  const sendNotification = jest.fn()
+  const addRewardToRedemptionsList = jest.fn()
+  const complete = jest.fn()
+
+  const rootStore = {
+    auth: {
+      login: jest.fn().mockResolvedValue(undefined),
+      challengeSudoMode: jest.fn(),
+      pendingProtectedAction: undefined,
+    },
+    profile: { currentProfile: { redemptionTfaEnabled: false } },
+    analytics: { trackSaladPayOpened: jest.fn() },
+    notifications: { sendNotification },
+    routing: { push },
+    balance: {
+      refreshBalance: jest.fn().mockResolvedValue(undefined),
+      refreshBalanceHistory: jest.fn().mockResolvedValue(undefined),
+    },
+    vault: { addRewardToRedemptionsList },
+  } as unknown as RootStore
+
+  const profile = { currentProfile: { redemptionTfaEnabled: false } } as unknown as ProfileStore
+  const axios = { post: postImpl } as unknown as AxiosInstance
+
+  const store = new RewardStore(rootStore, axios, profile)
+
+  // Replace the SaladPay instance with a stub that immediately resolves a payment response.
+  ;(store as any).saladPay = {
+    paymentRequest: () => ({
+      show: jest.fn().mockResolvedValue({ details: { transactionToken: 'tok' }, complete }),
+    }),
+  }
+
+  return { store, push, sendNotification, addRewardToRedemptionsList, complete }
+}
+
+describe('RewardStore.redeemReward 409 handling', () => {
+  it('treats a 409 on a RENDER reward as an error and returns to the reward detail page', async () => {
+    const post = jest.fn().mockRejectedValue(makeAxiosError(409))
+    const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: [renderRewardTag] })
+
+    await store.redeemReward(reward)
+
+    // Success side effects must not fire.
+    expect(addRewardToRedemptionsList).not.toHaveBeenCalled()
+    expect(store.isReviewing).toBe(false)
+
+    // Error notification with the exact copy.
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.category).toBe(NotificationMessageCategory.Error)
+    expect(notification.type).toBe('error')
+    expect(notification.message).toBe('No RENDER associated token account found for wallet you have provided')
+
+    // User is sent back to the reward detail page.
+    expect(push).toHaveBeenCalledWith('/rewards/render-1')
+  })
+
+  it('treats a 409 on a non-RENDER reward as the existing redemption success message', async () => {
+    const post = jest.fn().mockRejectedValue(makeAxiosError(409))
+    const { store, push, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'reward-2', name: 'Some Game' })
+
+    await store.redeemReward(reward)
+
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.category).toBe(NotificationMessageCategory.Redemption)
+    expect(notification.title).toContain('Thank you for ordering')
+    expect(push).not.toHaveBeenCalledWith('/rewards/reward-2')
+  })
+
+  it('does not apply the RENDER 409 handling to other error statuses', async () => {
+    const post = jest.fn().mockRejectedValue(makeAxiosError(500))
+    const { store, push, sendNotification } = setup(post)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: [renderRewardTag] })
+
+    await store.redeemReward(reward)
+
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.message).not.toBe('No RENDER associated token account found for wallet you have provided')
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -9,6 +9,7 @@ import { ChallengeSudoModeTrigger } from '../auth'
 import type { NotificationMessage } from '../notifications/models'
 import { NotificationMessageCategory } from '../notifications/models'
 import type { ProfileStore } from '../profile'
+import { isRenderReward } from '../render'
 import type { SaladPaymentResponse } from '../salad-pay'
 import { AbortError } from '../salad-pay'
 import { SaladPay } from '../salad-pay/SaladPay'
@@ -317,12 +318,28 @@ export class RewardStore {
               break
             case 409:
               this.clearRedemptionInfo()
-              notification = {
-                category: NotificationMessageCategory.Redemption,
-                title: `Thank you for ordering ${reward.name}!`,
-                message: 'Congrats on your pick! Your item is on its way. Check your reward vault for more details.',
-                onClick: () => this.store.routing.push('/store/vault'),
-                autoClose: false,
+              if (isRenderReward(reward)) {
+                // For a RENDER reward a 409 is a genuine failure (e.g. the user's wallet has no RENDER associated
+                // token account) rather than the idempotent "already redeemed" success it represents for other
+                // rewards. Surface it as an error and send the user back to the reward detail page.
+                notification = {
+                  category: NotificationMessageCategory.Error,
+                  // TODO: This copy is temporary; once the API returns a message for this case, surface that instead.
+                  title: 'Uh-oh! We could not complete your redemption.',
+                  message: 'No RENDER associated token account found for wallet you have provided',
+                  autoClose: false,
+                  onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
+                  type: 'error',
+                }
+                this.store.routing.push(`/rewards/${reward.id}`)
+              } else {
+                notification = {
+                  category: NotificationMessageCategory.Redemption,
+                  title: `Thank you for ordering ${reward.name}!`,
+                  message: 'Congrats on your pick! Your item is on its way. Check your reward vault for more details.',
+                  onClick: () => this.store.routing.push('/store/vault'),
+                  autoClose: false,
+                }
               }
               break
             case 400:

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -9,7 +9,6 @@ import { ChallengeSudoModeTrigger } from '../auth'
 import type { NotificationMessage } from '../notifications/models'
 import { NotificationMessageCategory } from '../notifications/models'
 import type { ProfileStore } from '../profile'
-import { isRenderReward } from '../render'
 import type { SaladPaymentResponse } from '../salad-pay'
 import { AbortError } from '../salad-pay'
 import { SaladPay } from '../salad-pay/SaladPay'
@@ -24,6 +23,16 @@ import type { RewardResource } from './models/RewardResource'
 import { rewardFromResource } from './utils'
 
 const timeoutMessage = 'request-timeout'
+
+/**
+ * Problem `type` codes returned on a `400` when a redemption is rejected because the account is missing a
+ * prerequisite (e.g. a RENDER associated token account or a configured Solana wallet). The API returns these as
+ * RFC 7807 problem responses carrying a human-readable message, so we surface that message rather than hardcoding
+ * copy. Matching is done on the `redemptions:requires:` family prefix so new prerequisites are covered automatically.
+ */
+export const renderTokenAccountRequiredProblemType = 'redemptions:requires:renderTokenAccount'
+export const solanaWalletRequiredProblemType = 'redemptions:requires:solanaWallet'
+const redemptionRequiresProblemTypePrefix = 'redemptions:requires:'
 
 export class RewardStore {
   private readonly saladPay = new SaladPay('43e8e26fa9077bb9c932d1849f52ef68e89c3ca39287c949275e0f18be6d074b')
@@ -318,28 +327,12 @@ export class RewardStore {
               break
             case 409:
               this.clearRedemptionInfo()
-              if (isRenderReward(reward)) {
-                // For a RENDER reward a 409 is a genuine failure (e.g. the user's wallet has no RENDER associated
-                // token account) rather than the idempotent "already redeemed" success it represents for other
-                // rewards. Surface it as an error and send the user back to the reward detail page.
-                notification = {
-                  category: NotificationMessageCategory.Error,
-                  // TODO: This copy is temporary; once the API returns a message for this case, surface that instead.
-                  title: 'Uh-oh! We could not complete your redemption.',
-                  message: 'No RENDER associated token account found for wallet you have provided',
-                  autoClose: false,
-                  onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
-                  type: 'error',
-                }
-                this.store.routing.push(`/rewards/${reward.id}`)
-              } else {
-                notification = {
-                  category: NotificationMessageCategory.Redemption,
-                  title: `Thank you for ordering ${reward.name}!`,
-                  message: 'Congrats on your pick! Your item is on its way. Check your reward vault for more details.',
-                  onClick: () => this.store.routing.push('/store/vault'),
-                  autoClose: false,
-                }
+              notification = {
+                category: NotificationMessageCategory.Redemption,
+                title: `Thank you for ordering ${reward.name}!`,
+                message: 'Congrats on your pick! Your item is on its way. Check your reward vault for more details.',
+                onClick: () => this.store.routing.push('/store/vault'),
+                autoClose: false,
               }
               break
             case 400:
@@ -366,6 +359,22 @@ export class RewardStore {
                     onClick: () => this.store.routing.push('/account/summary'),
                     type: 'error',
                   }
+                } else if (data.type.startsWith(redemptionRequiresProblemTypePrefix)) {
+                  // The redemption was rejected because the account is missing a prerequisite (e.g. a RENDER
+                  // associated token account or a configured Solana wallet). The API returns a human-readable
+                  // message in the problem body, so surface that instead of hardcoding copy, and send the user
+                  // back to the reward detail page to resolve the issue.
+                  const title = typeof data.title === 'string' && data.title ? data.title : undefined
+                  const detail = typeof data.detail === 'string' && data.detail ? data.detail : undefined
+                  notification = {
+                    category: NotificationMessageCategory.Error,
+                    title: title ?? 'Uh-oh! We could not complete your redemption.',
+                    message: detail ?? error.message ?? 'Please try again later',
+                    autoClose: false,
+                    onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
+                    type: 'error',
+                  }
+                  this.store.routing.push(`/rewards/${reward.id}`)
                 } else if (data.type === 'redemptions:dailySpendLimitExceeded') {
                   notification = {
                     category: NotificationMessageCategory.Error,

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -28,11 +28,11 @@ const timeoutMessage = 'request-timeout'
  * Problem `type` codes returned on a `400` when a redemption is rejected because the account is missing a
  * prerequisite (e.g. a RENDER associated token account or a configured Solana wallet). The API returns these as
  * RFC 7807 problem responses carrying a human-readable message, so we surface that message rather than hardcoding
- * copy. Matching is done on the `redemptions:requires:` family prefix so new prerequisites are covered automatically.
+ * copy. We match the known prerequisite codes explicitly (consistent with the other problem-type branches);
+ * any new `redemptions:requires:*` code must be added here explicitly.
  */
 export const renderTokenAccountRequiredProblemType = 'redemptions:requires:renderTokenAccount'
 export const solanaWalletRequiredProblemType = 'redemptions:requires:solanaWallet'
-const redemptionRequiresProblemTypePrefix = 'redemptions:requires:'
 
 export class RewardStore {
   private readonly saladPay = new SaladPay('43e8e26fa9077bb9c932d1849f52ef68e89c3ca39287c949275e0f18be6d074b')
@@ -359,8 +359,11 @@ export class RewardStore {
                     onClick: () => this.store.routing.push('/account/summary'),
                     type: 'error',
                   }
-                } else if (data.type.startsWith(redemptionRequiresProblemTypePrefix)) {
-                  // The redemption was rejected because the account is missing a prerequisite (e.g. a RENDER
+                } else if (
+                  data.type === renderTokenAccountRequiredProblemType ||
+                  data.type === solanaWalletRequiredProblemType
+                ) {
+                  // The redemption was rejected because the account is missing a known prerequisite (a RENDER
                   // associated token account or a configured Solana wallet). The API returns a human-readable
                   // message in the problem body, so surface that instead of hardcoding copy, and send the user
                   // back to the reward detail page to resolve the issue.

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -30,9 +30,9 @@ const timeoutMessage = 'request-timeout'
  * prerequisite (e.g. a RENDER associated token account or a configured Solana wallet). The API returns these as
  * RFC 7807 problem responses carrying a human-readable message, so we surface that message rather than hardcoding
  * copy. Each prerequisite code is handled in its own branch (consistent with the other problem-type branches);
- * any new `redemptions:requires:*` code must be added here explicitly. When the API omits a `title` we fall back to
- * a problem-specific title rather than generic copy, and the Solana case directs the user to the account page's
- * Solana wallet address input so they can resolve the issue.
+ * any new `redemptions:requires:*` code must be added here explicitly. When the API omits a `title` or `detail` we
+ * fall back to problem-specific copy rather than generic copy, and the Solana case directs the user to the account
+ * page's Solana wallet address input so they can resolve the issue.
  */
 export const renderTokenAccountRequiredProblemType = 'redemptions:requires:renderTokenAccount'
 export const solanaWalletRequiredProblemType = 'redemptions:requires:solanaWallet'
@@ -371,7 +371,7 @@ export class RewardStore {
                   notification = {
                     category: NotificationMessageCategory.Error,
                     title: title ?? 'RENDER token account required',
-                    message: detail ?? error.message ?? 'Please try again later',
+                    message: detail ?? 'A render token account is required',
                     autoClose: false,
                     onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
                     type: 'error',
@@ -387,7 +387,7 @@ export class RewardStore {
                   notification = {
                     category: NotificationMessageCategory.Error,
                     title: title ?? 'Solana wallet required',
-                    message: detail ?? error.message ?? 'Please try again later',
+                    message: detail ?? 'You need to add a solana wallet in order to purchase this reward',
                     autoClose: false,
                     onClick: () => this.store.routing.push(solanaWalletAccountAnchor),
                     type: 'error',

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -12,6 +12,7 @@ import type { ProfileStore } from '../profile'
 import type { SaladPaymentResponse } from '../salad-pay'
 import { AbortError } from '../salad-pay'
 import { SaladPay } from '../salad-pay/SaladPay'
+import { solanaWalletAccountAnchor } from '../solana-wallet'
 import {
   redemptionsEndpointPath,
   rewardsEndpointPath,
@@ -28,8 +29,10 @@ const timeoutMessage = 'request-timeout'
  * Problem `type` codes returned on a `400` when a redemption is rejected because the account is missing a
  * prerequisite (e.g. a RENDER associated token account or a configured Solana wallet). The API returns these as
  * RFC 7807 problem responses carrying a human-readable message, so we surface that message rather than hardcoding
- * copy. We match the known prerequisite codes explicitly (consistent with the other problem-type branches);
- * any new `redemptions:requires:*` code must be added here explicitly.
+ * copy. Each prerequisite code is handled in its own branch (consistent with the other problem-type branches);
+ * any new `redemptions:requires:*` code must be added here explicitly. When the API omits a `title` we fall back to
+ * a problem-specific title rather than generic copy, and the Solana case directs the user to the account page's
+ * Solana wallet address input so they can resolve the issue.
  */
 export const renderTokenAccountRequiredProblemType = 'redemptions:requires:renderTokenAccount'
 export const solanaWalletRequiredProblemType = 'redemptions:requires:solanaWallet'
@@ -359,22 +362,34 @@ export class RewardStore {
                     onClick: () => this.store.routing.push('/account/summary'),
                     type: 'error',
                   }
-                } else if (
-                  data.type === renderTokenAccountRequiredProblemType ||
-                  data.type === solanaWalletRequiredProblemType
-                ) {
-                  // The redemption was rejected because the account is missing a known prerequisite (a RENDER
-                  // associated token account or a configured Solana wallet). The API returns a human-readable
-                  // message in the problem body, so surface that instead of hardcoding copy, and send the user
-                  // back to the reward detail page to resolve the issue.
+                } else if (data.type === renderTokenAccountRequiredProblemType) {
+                  // The redemption was rejected because the account is missing a RENDER associated token account.
+                  // The API returns a human-readable message in the problem body, so surface that instead of
+                  // hardcoding copy, and send the user back to the reward detail page to resolve the issue.
                   const title = typeof data.title === 'string' && data.title ? data.title : undefined
                   const detail = typeof data.detail === 'string' && data.detail ? data.detail : undefined
                   notification = {
                     category: NotificationMessageCategory.Error,
-                    title: title ?? 'Uh-oh! We could not complete your redemption.',
+                    title: title ?? 'RENDER token account required',
                     message: detail ?? error.message ?? 'Please try again later',
                     autoClose: false,
                     onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
+                    type: 'error',
+                  }
+                  this.store.routing.push(`/rewards/${reward.id}`)
+                } else if (data.type === solanaWalletRequiredProblemType) {
+                  // The redemption was rejected because the account has no configured Solana wallet. The API
+                  // returns a human-readable message in the problem body, so surface that instead of hardcoding
+                  // copy. Send the user back to the reward detail page, and point the notification's onClick at the
+                  // account page's Solana wallet address input so they can add a wallet to resolve the issue.
+                  const title = typeof data.title === 'string' && data.title ? data.title : undefined
+                  const detail = typeof data.detail === 'string' && data.detail ? data.detail : undefined
+                  notification = {
+                    category: NotificationMessageCategory.Error,
+                    title: title ?? 'Solana wallet required',
+                    message: detail ?? error.message ?? 'Please try again later',
+                    autoClose: false,
+                    onClick: () => this.store.routing.push(solanaWalletAccountAnchor),
                     type: 'error',
                   }
                   this.store.routing.push(`/rewards/${reward.id}`)


### PR DESCRIPTION
# Plan (revision): Problem-specific fallback messages for the prerequisite branches

## Goal
In `packages/web-app/src/modules/reward/RewardStore.tsx`, update the fallback **`message`** in each `redemptions:requires:*` branch so that when the API omits `detail`, the notification shows problem-specific copy instead of the generic `error.message ?? 'Please try again later'`.

- RENDER token account branch → fallback message: **"A render token account is required"**
- Solana wallet branch → fallback message: **"You need to add a solana wallet in order to purchase this reward"**

Everything else stays as-is: API `detail` is still preferred when present, the fallback titles (`"RENDER token account required"` / `"Solana wallet required"`) are unchanged, `onClick` targets are unchanged (reward detail for RENDER; `solanaWalletAccountAnchor` for Solana), both still immediately redirect to `/rewards/${reward.id}`, and no success side effects fire.

## Changes

### RENDER token account branch
- Change the `message` fallback from `detail ?? error.message ?? 'Please try again later'` to `detail ?? 'A render token account is required'`.

### Solana wallet branch
- Change the `message` fallback from `detail ?? error.message ?? 'Please try again later'` to `detail ?? 'You need to add a solana wallet in order to purchase this reward'`.

### Comment
- Adjust the doc comment to note the fallback messages are problem-specific (used only when the API omits `detail`).

## Tests
Update `RewardStore.test.ts`:
- For each branch, add/adjust a case where the API response omits `detail` and assert the notification `message` equals the new problem-specific copy (RENDER → "A render token account is required"; Solana → "You need to add a solana wallet in order to purchase this reward").
- Keep the existing cases where `detail` is present (message equals the API `detail`), the fallback-title assertions, `onClick` targets, no-success-side-effects, `isReviewing === false`, immediate redirect, and the unrelated-`400` / `409` / `500` cases.

## Risks / to confirm
- **Title vs message**: I'm treating "backup message" as the `message` fallback (the copy reads as a sentence, not a title), leaving the fallback titles unchanged. If you actually wanted these strings as the fallback *titles*, say so and I'll swap them there instead.
- **Copy wording**: using the exact strings you gave ("something like…"). Happy to tweak capitalization (e.g. "RENDER" / "Solana") if you'd prefer.