### PR TITLE
[Web App] Implement RENDER quote validation

### DIFF
--- a/packages/web-app/src/modules/reward/RewardStore.test.ts
+++ b/packages/web-app/src/modules/reward/RewardStore.test.ts
@@ -27,6 +27,8 @@ import { solanaWalletAccountAnchor } from '../solana-wallet'
 import type { Reward } from './models/Reward'
 import {
   RewardStore,
+  renderExchangeRateDriftProblemType,
+  renderExchangeRateRequiredProblemType,
   renderTokenAccountRequiredProblemType,
   solanaWalletRequiredProblemType,
 } from './RewardStore'
@@ -54,7 +56,7 @@ interface Harness {
   complete: jest.Mock
 }
 
-const setup = (postImpl: jest.Mock): Harness => {
+const setup = (postImpl: jest.Mock, exchangeRate?: number): Harness => {
   const push = jest.fn()
   const sendNotification = jest.fn()
   const addRewardToRedemptionsList = jest.fn()
@@ -75,6 +77,7 @@ const setup = (postImpl: jest.Mock): Harness => {
       refreshBalanceHistory: jest.fn().mockResolvedValue(undefined),
     },
     vault: { addRewardToRedemptionsList },
+    render: { exchangeRate: exchangeRate !== undefined ? { rate: exchangeRate } : undefined },
   } as unknown as RootStore
 
   const profile = { currentProfile: { redemptionTfaEnabled: false } } as unknown as ProfileStore
@@ -271,5 +274,117 @@ describe('RewardStore.redeemReward other statuses', () => {
     const notification = sendNotification.mock.calls[0][0] as NotificationMessage
     expect(notification.category).toBe(NotificationMessageCategory.Error)
     expect(push).not.toHaveBeenCalled()
+  })
+})
+
+describe('RewardStore.redeemReward RENDER quoted exchange rate', () => {
+  it('attaches the quoted exchange rate held in state to a RENDER redemption request', async () => {
+    const post = jest.fn().mockResolvedValue({ data: { timestamp: '2026-07-02T00:00:00.000Z' } })
+    const { store } = setup(post, 0.9997)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: ['render'] })
+
+    await store.redeemReward(reward)
+
+    expect(post).toHaveBeenCalledTimes(1)
+    const body = post.mock.calls[0][1]
+    expect(body).toMatchObject({ rewardId: 'render-1', price: 10, quotedExchangeRate: 0.9997 })
+  })
+
+  it('does not attach a quoted exchange rate for a non-RENDER redemption request', async () => {
+    const post = jest.fn().mockResolvedValue({ data: { timestamp: '2026-07-02T00:00:00.000Z' } })
+    const { store } = setup(post, 0.9997)
+    const reward = makeReward({ id: 'reward-2', name: 'Some Game', tags: [] })
+
+    await store.redeemReward(reward)
+
+    const body = post.mock.calls[0][1]
+    expect(body).not.toHaveProperty('quotedExchangeRate')
+  })
+
+  it('omits the quoted exchange rate when no live rate is held for a RENDER reward', async () => {
+    const post = jest.fn().mockResolvedValue({ data: { timestamp: '2026-07-02T00:00:00.000Z' } })
+    const { store } = setup(post)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: ['render'] })
+
+    await store.redeemReward(reward)
+
+    const body = post.mock.calls[0][1]
+    expect(body).not.toHaveProperty('quotedExchangeRate')
+  })
+
+  it('shows a stale-quote toast and returns to the reward detail page on exchangeRateDrift', async () => {
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type: renderExchangeRateDriftProblemType, status: 400 }))
+    const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post, 0.5)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: ['render'] })
+
+    await store.redeemReward(reward)
+
+    // Success side effects must not fire.
+    expect(addRewardToRedemptionsList).not.toHaveBeenCalled()
+    expect(store.isReviewing).toBe(false)
+
+    // A user-facing toast explains the quote changed.
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.category).toBe(NotificationMessageCategory.Error)
+    expect(notification.type).toBe('error')
+    expect(notification.title).toBe('Uh-oh! The RENDER exchange rate has changed.')
+
+    // User is sent back to the reward detail page, where quote polling refreshes the displayed rate.
+    expect(push).toHaveBeenCalledWith('/rewards/render-1')
+    notification.onClick?.()
+    expect(push).toHaveBeenCalledWith('/rewards/render-1')
+  })
+
+  it('surfaces the API message for exchangeRateDrift when provided', async () => {
+    const apiTitle = 'The RENDER quote expired'
+    const apiDetail = 'The rate moved by more than the allowed tolerance.'
+    const post = jest
+      .fn()
+      .mockRejectedValue(
+        makeAxiosError(400, {
+          type: renderExchangeRateDriftProblemType,
+          status: 400,
+          title: apiTitle,
+          detail: apiDetail,
+        }),
+      )
+    const { store, sendNotification } = setup(post, 0.5)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: ['render'] })
+
+    await store.redeemReward(reward)
+
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.title).toBe(apiTitle)
+    expect(notification.message).toBe(apiDetail)
+  })
+
+  it('shows a generic error toast, logs, and returns to the reward detail page on exchangeRateRequired', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const post = jest
+      .fn()
+      .mockRejectedValue(makeAxiosError(400, { type: renderExchangeRateRequiredProblemType, status: 400 }))
+    const { store, push, sendNotification, addRewardToRedemptionsList } = setup(post, 0.5)
+    const reward = makeReward({ id: 'render-1', name: 'RENDER Tokens', tags: ['render'] })
+
+    await store.redeemReward(reward)
+
+    // Success side effects must not fire.
+    expect(addRewardToRedemptionsList).not.toHaveBeenCalled()
+    expect(store.isReviewing).toBe(false)
+
+    // A generic error toast is shown.
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const notification = sendNotification.mock.calls[0][0] as NotificationMessage
+    expect(notification.category).toBe(NotificationMessageCategory.Error)
+    expect(notification.title).toBe('Uh-oh! We could not complete your redemption.')
+
+    // The integration issue is logged and the user is routed back to the reward detail page.
+    expect(errorSpy).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/rewards/render-1')
+
+    errorSpy.mockRestore()
   })
 })

--- a/packages/web-app/src/modules/reward/RewardStore.tsx
+++ b/packages/web-app/src/modules/reward/RewardStore.tsx
@@ -9,6 +9,7 @@ import { ChallengeSudoModeTrigger } from '../auth'
 import type { NotificationMessage } from '../notifications/models'
 import { NotificationMessageCategory } from '../notifications/models'
 import type { ProfileStore } from '../profile'
+import { isRenderReward } from '../render'
 import type { SaladPaymentResponse } from '../salad-pay'
 import { AbortError } from '../salad-pay'
 import { SaladPay } from '../salad-pay/SaladPay'
@@ -36,6 +37,21 @@ const timeoutMessage = 'request-timeout'
  */
 export const renderTokenAccountRequiredProblemType = 'redemptions:requires:renderTokenAccount'
 export const solanaWalletRequiredProblemType = 'redemptions:requires:solanaWallet'
+
+/**
+ * Problem `type` codes returned on a `400` when a RENDER redemption is rejected because of a problem with the
+ * quoted exchange rate that the client attached to the request.
+ *
+ * - `exchangeRateDrift` means the RENDER/USD price the Chef was quoted has moved too far from the live rate for the
+ *   redemption to honor it. This is user-facing and expected to happen occasionally (quotes are time-sensitive): we
+ *   show the Chef a toast explaining the quote changed and send them back to the reward detail page, where the
+ *   price-quote polling re-fetches and displays the updated quote so they can review and try again.
+ * - `exchangeRateRequired` means the request reached the API without a `quotedExchangeRate`. Since the web app always
+ *   attaches the rate for RENDER redemptions, this is a defensive/dev-facing code that should never occur in practice;
+ *   we fail gracefully with a generic error toast + the same navigate-back behavior and log it for diagnosis.
+ */
+export const renderExchangeRateDriftProblemType = 'redemptions:invalid:exchangeRateDrift'
+export const renderExchangeRateRequiredProblemType = 'redemptions:invalid:exchangeRateRequired'
 
 export class RewardStore {
   private readonly saladPay = new SaladPay('43e8e26fa9077bb9c932d1849f52ef68e89c3ca39287c949275e0f18be6d074b')
@@ -286,9 +302,20 @@ export class RewardStore {
 
       console.log(`Completed SaladPay transaction ${response?.details.transactionToken}`)
 
+      // RENDER redemptions are priced against a live, time-sensitive RENDER/USD quote. Attach the exact rate the Chef
+      // was shown (the value the store is already holding and rendering the "you'll receive X RENDER" figure from) so
+      // the API can honor that quote or reject it with `exchangeRateDrift` if the live rate has moved too far. We reuse
+      // the state value rather than re-fetching so the quoted rate matches what the user actually saw.
+      const quotedExchangeRate = isRenderReward(reward) ? this.store.render.exchangeRate?.rate : undefined
+
       const newRedemption = yield this.axios.post(
         redemptionsEndpointPath,
-        { id: this.lastRedemptionId, price: reward.price, rewardId: reward.id },
+        {
+          id: this.lastRedemptionId,
+          price: reward.price,
+          rewardId: reward.id,
+          ...(quotedExchangeRate !== undefined ? { quotedExchangeRate } : {}),
+        },
         { timeoutErrorMessage: timeoutMessage },
       )
 
@@ -353,6 +380,41 @@ export class RewardStore {
                     onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
                     type: 'error',
                   }
+                } else if (data.type === renderExchangeRateDriftProblemType) {
+                  // The RENDER/USD quote the Chef was shown has drifted too far from the live rate for the API to
+                  // honor it. Send them back to the reward detail page, where the price-quote polling re-fetches and
+                  // displays the updated quote so they can review the new amount and try again. The API returns a
+                  // human-readable message in the problem body, so surface that when present.
+                  const title = typeof data.title === 'string' && data.title ? data.title : undefined
+                  const detail = typeof data.detail === 'string' && data.detail ? data.detail : undefined
+                  notification = {
+                    category: NotificationMessageCategory.Error,
+                    title: title ?? 'Uh-oh! The RENDER exchange rate has changed.',
+                    message:
+                      detail ??
+                      'The RENDER price moved while you were checking out. Please review the updated quote and try again.',
+                    autoClose: false,
+                    onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
+                    type: 'error',
+                  }
+                  this.store.routing.push(`/rewards/${reward.id}`)
+                } else if (data.type === renderExchangeRateRequiredProblemType) {
+                  // Defensive: the web app always attaches `quotedExchangeRate` for RENDER redemptions, so a missing
+                  // rate points at an integration bug rather than normal user flow. Fail gracefully with a generic
+                  // error toast + the same navigate-back behavior, and log it so the integration issue is diagnosable.
+                  console.error(
+                    'RewardStore -> redeemReward: RENDER redemption rejected for missing quotedExchangeRate',
+                    data,
+                  )
+                  notification = {
+                    category: NotificationMessageCategory.Error,
+                    title: 'Uh-oh! We could not complete your redemption.',
+                    message: 'Something went wrong with the RENDER quote. Please return to the reward and try again.',
+                    autoClose: false,
+                    onClick: () => this.store.routing.push(`/rewards/${reward.id}`),
+                    type: 'error',
+                  }
+                  this.store.routing.push(`/rewards/${reward.id}`)
                 } else if (data.type === 'redemptions:requires:minecraftUsername') {
                   notification = {
                     category: NotificationMessageCategory.FurtherActionRequired,


### PR DESCRIPTION
# Implement RENDER Quote Validation

## Goal
Attach `quotedExchangeRate` to every RENDER redemption request, and handle the two new backend `400`s (`redemptions:invalid:exchangeRateRequired`, `redemptions:invalid:exchangeRateDrift`) by showing a toast and routing the Chef back to the reward details page, where existing logic re-fetches and displays the updated quote.

## Where the work likely lives
Since the code isn't visible from here, confirm these touch points first (grep for `exchange-rate`, `render`, `redeem`/`redemption`, and the reward details route):
- **Redemption request/DTO type** — the model/interface for the redeem call body (add `quotedExchangeRate`).
- **Redeem API client/service** — the function that POSTs the redemption (RTK Query mutation, saga, or service method).
- **Redeem action handler / component** — the RENDER reward details / redeem flow component that already fetches `/api/v2/render/exchange-rate` and holds the rate in state (confirmed: rate is available at redeem time).
- **Error handling layer** — wherever API error codes are mapped to toasts; add the two new codes.
- **i18n / copy** — toast message strings.

## Approach
1. **Attach the quoted rate.**
   - Add `quotedExchangeRate: number` to the redemption request type.
   - In the redeem handler, pass the exchange rate currently held in state (the same value used to render "you'll receive X RENDER") into the redeem call. No new fetch — reuse the state value so the quoted rate matches what the user saw.

2. **Handle the drift error (`redemptions:invalid:exchangeRateDrift`).**
   - On this `400`, show a toast notifying the user the quote was stale/changed.
   - Navigate back to the reward details page. Rely on the page's established logic to re-fetch the current exchange rate and show the updated quote (no new refresh code needed).

3. **Handle the required error (`redemptions:invalid:exchangeRateRequired`).**
   - Defensive/dev-facing — should never occur since we always attach the rate. Map it to a generic error toast + same navigate-back behavior so it fails gracefully. Log it if there's a logging/Slack path for integration issues.

4. **Copy.** Add toast message(s) for the stale-quote case (user-facing) and a generic fallback for the required case.

## Tests
- Unit: redeem handler includes `quotedExchangeRate` from state in the request body.
- Unit/reducer: `exchangeRateDrift` and `exchangeRateRequired` error codes trigger the toast + navigation action.
- Component/integration: mocked drift `400` → toast shown → user lands on reward details page with a refreshed quote.

## Risks / open questions
- **Exact field name & type** — confirm backend expects `quotedExchangeRate` as a number (RENDER/USD) matching `/api/v2/render/exchange-rate`'s shape.
- **Where drift can occur** — assuming redemption is a single request; if multi-step, attach the rate to the correct call.
- **Navigation target** — assuming there's a known route/id to return to the specific reward details page from the redeem context.
- **Error mapping location** — confirm whether errors are handled centrally or per-call so the two codes are caught in the right place.

Touch points will be verified against the actual code before implementing.