### PR TITLE
[Web App] Remove Feature Flags for RENDER and Solana

### DIFF
--- a/packages/web-app/src/modules/account-views/account-views/components/Account.tsx
+++ b/packages/web-app/src/modules/account-views/account-views/components/Account.tsx
@@ -10,7 +10,6 @@ import { Head } from '../../../../components'
 import { withLogin } from '../../../auth-views'
 import { type Passkey } from '../../../passkey-setup'
 import type { Avatar, Profile } from '../../../profile/models'
-import { renderRewardsEnabled } from '../../../render'
 import { solanaWalletAnchorId } from '../../../solana-wallet'
 import { AccountSecurityContainer } from './AccountSecurity/AccountSecurityContainer'
 import { AccountTermsAndConditionsUpdate } from './AccountTermsAndConditionsUpdate'
@@ -146,7 +145,7 @@ const _Account: FC<Props> = ({
   // custom scroll view to that section explicitly. The wallet panel mounts after its data loads, so poll briefly for
   // the element before giving up.
   useEffect(() => {
-    if (!renderRewardsEnabled || location.hash !== `#${solanaWalletAnchorId}`) {
+    if (location.hash !== `#${solanaWalletAnchorId}`) {
       return
     }
 
@@ -288,7 +287,7 @@ const _Account: FC<Props> = ({
             </div>
           </div>
           <AccountSecurityContainer />
-          {renderRewardsEnabled && <SolanaWalletContainer />}
+          <SolanaWalletContainer />
         </Layout>
       </Scrollbars>
     </div>

--- a/packages/web-app/src/modules/render/RenderStore.test.ts
+++ b/packages/web-app/src/modules/render/RenderStore.test.ts
@@ -4,31 +4,11 @@ import { RenderStore } from './RenderStore'
 const makeAxios = (get: jest.Mock): AxiosInstance => ({ get } as unknown as AxiosInstance)
 
 describe('RenderStore', () => {
-  it('does not fetch when the feature flag is off', async () => {
-    const get = jest.fn()
-    const store = new RenderStore(makeAxios(get), false)
-
-    await store.fetchExchangeRate()
-
-    expect(get).not.toHaveBeenCalled()
-    expect(store.exchangeRate).toBeUndefined()
-    expect(store.isLoadingExchangeRate).toBe(false)
-  })
-
-  it('does not poll when the feature flag is off', () => {
-    const get = jest.fn()
-    const store = new RenderStore(makeAxios(get), false)
-
-    store.startPollingExchangeRate()
-
-    expect(get).not.toHaveBeenCalled()
-  })
-
-  it('fetches and stores the quote when the flag is on', async () => {
+  it('fetches and stores the quote', async () => {
     const get = jest.fn().mockResolvedValue({
       data: { rate: 2.5, asOf: '2026-06-24T00:00:00.000Z', expiresAt: '2026-06-24T00:01:00.000Z' },
     })
-    const store = new RenderStore(makeAxios(get), true)
+    const store = new RenderStore(makeAxios(get))
 
     await store.fetchExchangeRate()
 
@@ -40,7 +20,7 @@ describe('RenderStore', () => {
 
   it('flags an error and clears loading when the request fails', async () => {
     const get = jest.fn().mockRejectedValue(new Error('boom'))
-    const store = new RenderStore(makeAxios(get), true)
+    const store = new RenderStore(makeAxios(get))
 
     await store.fetchExchangeRate()
 

--- a/packages/web-app/src/modules/render/RenderStore.tsx
+++ b/packages/web-app/src/modules/render/RenderStore.tsx
@@ -1,14 +1,11 @@
 import type { AxiosInstance, AxiosResponse } from 'axios'
 import { action, flow, observable } from 'mobx'
-import { renderExchangeRateEndpointPath, renderExchangeRateRefreshRate, renderRewardsEnabled } from './constants'
+import { renderExchangeRateEndpointPath, renderExchangeRateRefreshRate } from './constants'
 import type { RenderExchangeRate, RenderExchangeRateResource } from './models'
 import { isExchangeRateStale, renderExchangeRateFromResource } from './utils'
 
 /**
  * Owns the live RENDER/USD price quote that powers the price-quote feature.
- *
- * All fetching is gated behind the internal {@link renderRewardsEnabled} flag: when the flag is off the store
- * never touches the network and `exchangeRate` stays `undefined`.
  */
 export class RenderStore {
   @observable
@@ -25,15 +22,8 @@ export class RenderStore {
 
   /**
    * @param axios The App API client.
-   * @param enabled Whether the RENDER feature is on. Defaults to the hard-coded {@link renderRewardsEnabled}
-   *   flag; injectable so tests can exercise both the on and off paths.
    */
-  public constructor(private readonly axios: AxiosInstance, private readonly enabled: boolean = renderRewardsEnabled) {}
-
-  /** Whether the price-quote feature is enabled. */
-  public get isEnabled(): boolean {
-    return this.enabled
-  }
+  public constructor(private readonly axios: AxiosInstance) {}
 
   /** Whether the currently held quote should be treated as stale. */
   public get isExchangeRateStale(): boolean {
@@ -44,14 +34,9 @@ export class RenderStore {
    * Registers a RENDER reward view as active and begins polling for fresh quotes.
    *
    * Reference-counted so multiple simultaneous views (e.g. reward detail and checkout) share a single poll loop.
-   * Returns a no-op when the feature flag is disabled so callers never trigger network activity while dark.
    */
   @action.bound
   public startPollingExchangeRate(): void {
-    if (!this.isEnabled) {
-      return
-    }
-
     this.activeViewers += 1
 
     if (this.pollingHandle !== undefined) {
@@ -77,13 +62,9 @@ export class RenderStore {
     }
   }
 
-  /** Fetches the current RENDER/USD quote. No-ops while the feature flag is disabled. */
+  /** Fetches the current RENDER/USD quote. */
   @action.bound
   public fetchExchangeRate = flow(function* (this: RenderStore) {
-    if (!this.isEnabled) {
-      return
-    }
-
     this.isLoadingExchangeRate = true
     this.hasExchangeRateError = false
 

--- a/packages/web-app/src/modules/render/constants.tsx
+++ b/packages/web-app/src/modules/render/constants.tsx
@@ -1,15 +1,4 @@
 /**
- * Internal, hard-coded feature flag that gates the entire RENDER token integration.
- *
- * This is the single source of truth for every RENDER workflow: the price-quote UI, the RENDER reward pricing shown
- * across the storefront/search/detail/checkout flows, and the Solana wallet account panel are all gated behind this
- * one flag. It is intentionally a compile-time constant rather than a remote/third-party flag (e.g. Unleash): the
- * feature ships dark while this is `false` — no RENDER UI is rendered and no calls are made to the exchange-rate or
- * Solana wallet endpoints. Flip it to `true` and redeploy to turn the feature on.
- */
-export const renderRewardsEnabled = true
-
-/**
  * The App API endpoint that returns the current RENDER/USD price quote.
  *
  * This endpoint is the single source of truth for the RENDER price: the rate is computed server-side and the web app

--- a/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RenderPriceQuote/RenderPriceQuoteContainer.tsx
@@ -2,7 +2,7 @@ import { observer } from 'mobx-react'
 import type { FC } from 'react'
 import { useEffect } from 'react'
 import { getStore } from '../../../../Store'
-import { computeRenderQuote, isRenderReward, renderRewardsEnabled } from '../../../render'
+import { computeRenderQuote, isRenderReward } from '../../../render'
 import type { Reward } from '../../../reward/models'
 import { RenderPriceQuote } from './RenderPriceQuote'
 
@@ -18,11 +18,11 @@ export interface RenderPriceQuoteContainerProps {
 /**
  * Surfaces a live RENDER price quote for a reward.
  *
- * Renders nothing — and triggers no network activity — unless the internal {@link renderRewardsEnabled} flag is
- * on and the reward is a RENDER reward. While active it keeps the quote fresh via the {@link RenderStore} poll loop.
+ * Renders nothing — and triggers no network activity — unless the reward is a RENDER reward. While active it keeps
+ * the quote fresh via the {@link RenderStore} poll loop.
  */
 const _RenderPriceQuoteContainer: FC<RenderPriceQuoteContainerProps> = ({ reward, saladBalance, variant }) => {
-  const active = renderRewardsEnabled && isRenderReward(reward)
+  const active = isRenderReward(reward)
   const store = getStore()
   const render = store.render
 

--- a/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
+++ b/packages/web-app/src/modules/reward-views/components/RewardHeaderBar.tsx
@@ -5,7 +5,6 @@ import type { WithStyles } from 'react-jss'
 import withStyles from 'react-jss'
 import { Button, SmartLink } from '../../../components'
 import type { SaladTheme } from '../../../SaladTheme'
-import { renderRewardsEnabled } from '../../render'
 import type { Reward } from '../../reward/models'
 import { getPercentOff } from '../../reward/utils'
 import { rewardRequiresSolanaAddress, solanaWalletAccountAnchor } from '../../solana-wallet'
@@ -145,7 +144,7 @@ class _RewardHeaderBar extends Component<Props> {
   // wallet (mirroring the order-summary flow) so Buy Now can be hard-blocked until an address is on file.
   private maybeLoadSolanaWallet() {
     const { reward, authenticated, loadSolanaWallet } = this.props
-    if (renderRewardsEnabled && authenticated && rewardRequiresSolanaAddress(reward)) {
+    if (authenticated && rewardRequiresSolanaAddress(reward)) {
       loadSolanaWallet?.()
     }
   }
@@ -209,11 +208,7 @@ class _RewardHeaderBar extends Component<Props> {
     // Hard-block Buy Now when redeeming a reward that needs a Solana wallet the Chef hasn't set yet: RENDER token
     // rewards are paid out on-chain, so without an address on file there is nowhere to send them.
     const missingRequiredWallet =
-      renderRewardsEnabled &&
-      !!authenticated &&
-      rewardRequiresSolanaAddress(reward) &&
-      !isSolanaWalletLoading &&
-      !solanaWalletAddress
+      !!authenticated && rewardRequiresSolanaAddress(reward) && !isSolanaWalletLoading && !solanaWalletAddress
 
     const disabled = outOfStock || promoGame || (authenticated && !hasBalance) || missingRequiredWallet
 

--- a/packages/web-app/src/modules/salad-pay-views/components/SaladPayOrderSummaryPage.tsx
+++ b/packages/web-app/src/modules/salad-pay-views/components/SaladPayOrderSummaryPage.tsx
@@ -7,7 +7,6 @@ import { SaladPayPage } from '.'
 import type { SaladTheme } from '../../../SaladTheme'
 import { SmartLink } from '../../../components'
 import { currencyFormatter } from '../../../formatters'
-import { renderRewardsEnabled } from '../../render'
 import { RenderPriceQuoteContainer } from '../../reward-views/components/RenderPriceQuote'
 import type { Reward } from '../../reward/models'
 import type { SaladPaymentRequestOptions } from '../../salad-pay/models'
@@ -129,7 +128,7 @@ const _SaladPayOrderSummaryPage: FC<Props> = ({
   // Hard-block checkout when redeeming a reward that needs a Solana wallet the Chef hasn't set yet: RENDER token
   // rewards are paid out on-chain, so without an address on file there is nowhere to send them.
   const missingRequiredWallet =
-    renderRewardsEnabled && rewardRequiresSolanaAddress(reward) && !isSolanaWalletLoading && !solanaWalletAddress
+    rewardRequiresSolanaAddress(reward) && !isSolanaWalletLoading && !solanaWalletAddress
 
   const canConfirm = hasEnoughBalance && !missingRequiredWallet
 
@@ -140,7 +139,7 @@ const _SaladPayOrderSummaryPage: FC<Props> = ({
   }
 
   useEffect(() => {
-    if (renderRewardsEnabled && rewardRequiresSolanaAddress(reward)) {
+    if (rewardRequiresSolanaAddress(reward)) {
       loadSolanaWallet?.()
     }
     // Re-evaluate only when the reward changes.

--- a/packages/web-app/src/modules/solana-wallet/constants.tsx
+++ b/packages/web-app/src/modules/solana-wallet/constants.tsx
@@ -1,8 +1,5 @@
 /**
  * Endpoint used to get/set/clear the authenticated user's Solana wallet address.
- *
- * Note: the Solana wallet UI is gated behind the single RENDER feature flag
- * (`renderRewardsEnabled` in the `render` module), so there is no separate flag here.
  */
 export const solanaWalletEndpointPath = '/api/v2/solana/wallet'
 


### PR DESCRIPTION
# Plan: Remove RENDER & Solana Feature Flags (salad-applications)

## Goal
Fully remove the feature flags gating the RENDER rewards and Solana wallet features. Keep only the enabled code paths; delete flag checks, flag definitions in the app, and any now-dead "feature off" fallback UI. No kill-switch retained.

## Step 1 — Enumerate the flags (discovery)
Since the exact identifiers aren't known yet, start with a repo-wide search to build the authoritative list before editing:

- Grep (case-insensitive) for: `render`, `solana`, `wallet`, plus common flag prefixes/suffixes used in this repo (e.g. `useFlag`, `featureFlag`, `flags.`, `isEnabled`, `LaunchDarkly`/`ld`, config constants).
- Identify how flags are resolved in this codebase (remote flag service vs. local config/constants/env) and the canonical flag-lookup hook/util.
- Produce a concrete list of flag keys (e.g. `renderRewards`, `solanaWallet` or similar) and every file that references them.

Deliverable of this step: a checklist of flag keys + reference sites that drives the edits below.

## Step 2 — Remove flag checks, keep enabled branch
For every reference found, delete the conditional and inline the enabled path:

- **Flag definitions/registry**: remove the RENDER/Solana flag keys from the app's flag list/enum/defaults.
- **Storefront discovery & search**: remove gating so RENDER rewards always appear; drop any "hidden when flag off" filters.
- **Redemption flow**: remove flag guards around the redeem RENDER path, price-quote/stale-quote review, and explorer link.
- **Wallet management UI**: remove gating around add/remove Solana wallet address screens/components.
- **Reward vault**: remove gating around RENDER redemption history display.
- **Routing/navigation**: remove any conditional route registration or nav entries tied to these flags.
- **Fallback UI**: delete now-unreachable "feature unavailable/off" components, empty states, and their imports.

Pattern per site:
- `if (flag) { <feature> }` → keep `<feature>` unconditionally.
- Ternaries / conditional render → keep the enabled JSX, delete the alternative.
- Remove the flag from hook calls, selectors, props, and context once no longer referenced.

## Step 3 — Clean up dead code
- Remove unused imports, helper functions, constants, and types left orphaned after inlining.
- Remove flag-related props threaded purely to gate these features.
- Ensure no dangling references to deleted fallback components.

## Scope boundaries
- **In scope**: all in-repo flag references, flag definitions/defaults in `salad-applications`, dead fallback UI.
- **Out of scope** (per your answer #2): flag-service/admin-side deletion (LaunchDarkly/remote config records). If flags are remote, the app will simply stop reading them; the remote records can be retired separately.

## Tests
- Update/remove any unit or component tests that assert flag-off behavior; keep/expand tests for the always-on behavior.
- Run the full test suite and typecheck/lint to catch orphaned references.
- Manual smoke (or existing e2e) of the key journeys: RENDER reward visible in storefront + search, wallet add/remove, redemption incl. stale-quote review + explorer link, reward vault history.

## Risks & mitigations
- **Missed reference / partial removal**: mitigated by the Step 1 grep inventory being the single source of truth; grep again after edits to confirm zero remaining references to the flag keys.
- **Non-standard Next.js conventions in this repo** (per AGENTS.md): consult `node_modules/next/dist/docs/` before touching any routing/config-level flag wiring.
- **Shared flag utilities**: if the flag hook/registry is shared, remove only the RENDER/Solana keys, not the mechanism.
- **Remote flag still returning false**: since we remove the read entirely, remote state no longer affects the app — verify no code still short-circuits on a cached/remote value.

## Definition of done
- No references to the RENDER/Solana flag keys remain anywhere in the repo.
- All five feature areas render unconditionally.
- No dead fallback UI or orphaned imports; tests, typecheck, and lint pass.